### PR TITLE
Use a variable for data.train.next_batch()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ X_test, y_test = mnist_reader.load_mnist('data/fashion', kind='t10k')
 from tensorflow.examples.tutorials.mnist import input_data
 data = input_data.read_data_sets('data/fashion')
 
-data.train.next_batch(100)
+data.train.next_batch(BATCH_SIZE)
 ```
 
 ### Loading data with other languages


### PR DESCRIPTION
Instead of an arbitrary constant, I think it might be better to document it to use a variable such as `BATCH_SIZE`. I can't recall which forum and question it was, but a user (someone who was still learning TensorFlow) was confused because of the loop counter in [Reading Data](https://www.tensorflow.org/api_guides/python/reading_data#csv_files) (CSV files section), `for i in range(1200)`. The user thought that `1200` was required constant or something.