### PR TITLE
Included a new dataloader for Fashion MNIST in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Also, an official Tensorflow tutorial of using `tf.keras`, a high-level API to t
 ### Loading data with other machine learning libraries 
 To date, the following libraries have included `Fashion-MNIST` as a built-in dataset. Therefore, you don't need to download `Fashion-MNIST` by yourself. Just follow their API and you are ready to go.
 
+- [Activeloop Hub](https://docs.activeloop.ai/datasets/fashion-mnist-dataset)
 - [Apache MXNet Gluon](https://mxnet.apache.org/api/python/docs/api/gluon/data/vision/datasets/index.html#mxnet.gluon.data.vision.datasets.FashionMNIST)
 - [TensorFlow.js](https://github.com/tensorflow/tfjs-examples/blob/master/fashion-mnist-vae/data.js)
 - [Kaggle](https://www.kaggle.com/zalando-research/fashionmnist)


### PR DESCRIPTION
Hey there,

We've added Fashion-MNIST to Activeloop Hub, an [open-source dataset format for AI](https://github.com/activeloopai/Hub). Users can now load Fashion-MNIST in seconds by running 

```
import hub
ds = hub.load('hub://activeloop/fashion-mnist-train')
```

(with Hub, they can stream the data instead of fully downloading it, so the access is much faster).

Hope this brings value to the community!

