### PR TITLE
Add Jupyter notebook for Fashion-MNIST confusion matrix visualization

### DIFF
--- a/examples/fashion-mnist-confusion-matrix.ipynb
+++ b/examples/fashion-mnist-confusion-matrix.ipynb
@@ -1,0 +1,662 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3eeb6284-306b-4ffe-9b8b-54737cd8af01",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-07 11:40:58.504896: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "434b760b-57d1-47cf-b99a-a0e0f619afb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mnist_data=tf.keras.datasets.fashion_mnist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4903c80d-0cdd-4603-95dc-7171d05f9962",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(train_images,train_labels),(test_images,test_labels)=mnist_data.load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "52adc0d3-0edc-4b58-bd96-1af43ae954ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[  0   0   0   0   1   0   0   0   0  22  88 188 172 132 125 141 199 143\n",
+      "    9   0   0   0   1   0   0   0   0   0]\n",
+      " [  0   0   0   1   0   0  20 131 199 206 196 202 242 255 255 250 222 197\n",
+      "  206 188 126  17   0   0   0   0   0   0]\n",
+      " [  0   0   0   1   0  35 214 191 183 178 175 168 150 162 159 152 158 179\n",
+      "  183 189 195 185  82   0   0   0   0   0]\n",
+      " [  0   0   0   0   0 170 190 172 177 176 171 169 162 155 148 154 169 174\n",
+      "  175 175 177 183 188  12   0   0   0   0]\n",
+      " [  0   0   0   0  25 194 180 178 174 184 187 189 187 184 181 189 200 197\n",
+      "  193 190 178 175 194  90   0   0   0   0]\n",
+      " [  0   0   0   0  42 218 191 197 208 204 211 209 210 212 211 214 215 213\n",
+      "  214 211 211 191 200 158   0   0   0   0]\n",
+      " [  0   0   0   0  88 221 215 217 219 211 185 150 118 107  99  88  83  90\n",
+      "  135 212 203 207 219 169   0   0   0   0]\n",
+      " [  0   0   0   0   0  27 118 162  40   0   0   0  10  19  28  39  47  36\n",
+      "    0   0 203 230 220 203   0   0   0   0]\n",
+      " [  0   0   0   0 138 136  71  69  54 216 217 203 184 168 163 162 163 178\n",
+      "  221 186  38  26   7   0   0   0   0   0]\n",
+      " [  0   0   0   0  67 134 154 224 129  66  81 117 129 128 132 137 131 129\n",
+      "   86  73 157 151 134 216  18   0   0   0]\n",
+      " [  0   0   0   0 203 198 172 183 206 255 255 250 243 240 239 235 238 244\n",
+      "  255 238 184 160  86  98   0   0   0   0]\n",
+      " [  0   0   0   0 122 188 224 151 105 127  97 100 105 114 117 117 113 103\n",
+      "   98 111 142 254 191 255  49   0   0   0]\n",
+      " [  0   0   0   0 163 179 200  95 154 198 197 200 200 198 197 198 199 202\n",
+      "  200 176  86 206 157 162  10   0   0   0]\n",
+      " [  0   0   0   0 197 201 229  71 144 194 181 183 179 182 180 179 180 190\n",
+      "  185 197  76 219 185 201  34   0   0   0]\n",
+      " [  0   0   0   0 199 193 226  58 154 192 184 187 184 186 184 185 183 192\n",
+      "  191 200  56 219 203 207  60   0   0   0]\n",
+      " [  0   0   0   0 201 194 224  41 163 190 186 186 184 185 183 185 178 190\n",
+      "  194 202  33 211 200 206  73   0   0   0]\n",
+      " [  0   0   0   0 201 197 222  17 172 190 186 187 182 186 185 187 180 187\n",
+      "  193 202  26 212 202 203  76   0   0   0]\n",
+      " [  0   0   0   0 200 197 223   0 177 189 184 185 178 184 183 184 180 183\n",
+      "  189 203  35 196 203 203  84   0   0   0]\n",
+      " [  0   0   0   0 200 197 223   0 185 187 185 187 180 184 182 183 178 182\n",
+      "  183 205  44 159 207 201  85   0   0   0]\n",
+      " [  0   0   0   0 187 198 225   0 194 188 184 185 180 183 183 184 181 181\n",
+      "  177 206  46 129 211 200  88   0   0   0]\n",
+      " [  0   0   0   6 186 200 211   0 199 189 184 184 185 182 183 184 185 182\n",
+      "  175 205  50  97 216 197  93   0   0   0]\n",
+      " [  0   0   0   5 185 204 184   0 202 188 182 182 183 183 184 182 180 182\n",
+      "  174 202  63  59 220 196  94   0   0   0]\n",
+      " [  0   0   0   5 184 206 157   0 204 187 187 189 192 190 190 191 190 187\n",
+      "  183 202  78  35 222 197  95   0   0   0]\n",
+      " [  0   0   0   5 183 208 127   0 197 166 153 149 149 146 148 149 150 151\n",
+      "  158 191  90   8 223 195  99   0   0   0]\n",
+      " [  0   0   0   6 184 208 114   0 204 173 161 180 176 172 173 173 174 176\n",
+      "  162 202 115   0 229 199 105   0   0   0]\n",
+      " [  0   0   0   9 178 204 115   0 121 135 114 117 114 114 117 118 119 117\n",
+      "  113 147  63   0 225 196 107   0   0   0]\n",
+      " [  0   0   0  18 180 206 131   0   0   0   0   0   0   0   0   0   0   0\n",
+      "    0   0   0   0 224 197 123   0   0   0]\n",
+      " [  0   0   0   0 141 151  76   0   1   1   0   0   0   0   0   0   0   0\n",
+      "    0   0   0   0 133 167  73   0   0   0]] 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "#random sample from datasets\n",
+    "print(train_images[5],train_labels[5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3d58f1ca-255c-4672-9fc9-6555438acc6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#plot the train image\n",
+    "\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3d5d6303-d70f-4f7e-93ef-893ddda2cf7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAGdCAYAAABU0qcqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAIxtJREFUeJzt3X9w1PW97/HXbn5sAiQbQ8gvCTSgQis/2lJJuSrFkgHSM15QbsdfdwY8XhhtcIrUatOroj2dmxbnWkeH4tyZFuqM+KtXYPR06FE0obYBC8rhUG1K0lSgkCDUZENCfmz2c//gmN7wQ/r+muSThOdjZmfI7r7y/ew33+WVb3bzTsg55wQAwCAL+14AAODSRAEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFBQQA8CLZ9wLOlkgkdPToUWVkZCgUCvleDgDAyDmn1tZWFRYWKhy+8HnOkCugo0ePqqioyPcyAACf0eHDhzV+/PgL3j7kCigjI0OSdJ2+oWSleF5NPwpyNjcCpyQlT7jcnGlcYM9ccctBc0aSjrRGzZmm+hxzJtxlPx56MnvMmX+aud+ckaR//Y/p5sxV37Pv80TrKXNmUPG8DSSubr2tX/X+f34hA1ZA69ev1+OPP67GxkbNnDlTTz/9tGbPnn3R3Cc/dktWipJDl3gBaeQdyMnhiDmTlJpmzqSMTjVnJCk5YV9fON2+vnDYfjy4dHsBpY4J9hwK8piSQ/Z9nhjqz3Get8H85y642MsoA/ImhBdffFFr1qzR2rVr9e6772rmzJlauHChjh8/PhCbAwAMQwNSQE888YRWrFihO++8U1/4whf0zDPPaNSoUfr5z38+EJsDAAxD/V5AXV1d2rt3r0pLS/++kXBYpaWlqqmpOef+nZ2disVifS4AgJGv3wvoxIkT6unpUV5eXp/r8/Ly1NjYeM79KysrFY1Gey+8Aw4ALg3efxG1oqJCLS0tvZfDhw/7XhIAYBD0+7vgcnJylJSUpKampj7XNzU1KT8//5z7RyIRRSL2dx4BAIa3fj8DSk1N1axZs7Rjx47e6xKJhHbs2KE5c+b09+YAAMPUgPwe0Jo1a7Rs2TJ95Stf0ezZs/Xkk0+qra1Nd95550BsDgAwDA1IAd1yyy366KOP9Mgjj6ixsVFf/OIXtX379nPemAAAuHSFnBtacyNisZii0ajmafHQnYQwhMdzJI+3j6354IELz2r6NP/12r3mzGXJ7eZMU1emOZOR3GHOSNLd2W+bM8UpYwJty+pUwv6YftUe7Ju+nS1TzZlxqa3mzAenzn1d+GL27LrKnJnyeIM5I0nxxqaL3wnniLtuVWmbWlpalJl54eev93fBAQAuTRQQAMALCggA4AUFBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwYkCmYaN/hGd+3pz5xvP2YZpjW+xDJCXpz6dyzJnTcfuA2e6eJHOmrSvVnJGkX/7hS+bMqNGd5kxPj/17v64u+9M1JaXHnJGkCdkfmzOHki8zZ8Yk2/fd/Ov/3Zz56JpgA2ObfmH/G2Zjf1YTaFuXIs6AAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAFxQQAMALCggA4AXTsINwblA283FltzlT0zzZnGmIZZszkpSWHDdnEi5kznQGmIYdCgX7GgWZbN3ZaX8axQNMtk4OMNk6Y1SHOSMFm1re2WN/TLHONHMmKZxhzoxO6TJnJOmKf641Z2Kv2KeC93xsnz4+EnAGBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwggICAHhBAQEAvKCAAABeMIx0kCRP+pw5M33sMXPmcFuWOTMqxT70VJI64/bDJzut3ZwZl24fepocSpgzkhR39u/JugIM4exK2AesZqWeNmcK0lrMGUnqTNiHkZ7uCTDANGHfd02n7cNIgww9laS8tFZzpvb2meZM7vrfmTMjAWdAAAAvKCAAgBcUEADACwoIAOAFBQQA8IICAgB4QQEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFw0gHSTw305y5NmofUPhmYqo5k5ncac5IUmGk2ZxpT6SaM9nJbeZMt7MP+5SkcIAhpimhHnMmEWDoaSRsHxqbpGBDWbud/b+GIPsuyNBT2Z9K2tc63h6SlJlsHwDbMc8+wFTr7ZGRgDMgAIAXFBAAwIt+L6BHH31UoVCoz2XqVPuPhQAAI9uAvAZ09dVX64033vj7RpJ5qQkA0NeANENycrLy8/MH4lMDAEaIAXkN6ODBgyosLNSkSZN0xx136NChQxe8b2dnp2KxWJ8LAGDk6/cCKikp0aZNm7R9+3Zt2LBBDQ0Nuv7669Xaev63JlZWVioajfZeioqK+ntJAIAhqN8LqKysTN/85jc1Y8YMLVy4UL/61a/U3Nysl1566bz3r6ioUEtLS+/l8OHD/b0kAMAQNODvDsjKytJVV12lurq6894eiUQUiUQGehkAgCFmwH8P6NSpU6qvr1dBQcFAbwoAMIz0ewHdf//9qq6u1l/+8hf97ne/00033aSkpCTddttt/b0pAMAw1u8/gjty5Ihuu+02nTx5UuPGjdN1112nXbt2ady4cf29KQDAMNbvBfTCCy/096ccET760mhzJi1kHz75X6L15kyQYZpncnFz5kTcPkny7b9NNmf+/VCw4ZNJh9LMmeS2kH07Aea/prQ5cybA/FJJUk/E/piar7YfD9/+2r+ZM8e77MfQVaOPmzOSNCH1hDnzm1H24/VSxSw4AIAXFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPAi5JyzTzgcQLFYTNFoVPO0WMmhFN/L8SrpyknmTN2deeZM5PMt5owkXf6/kswZ9/v/CLStwZKUaR90GcoYY8640enmTCLTnulJD/YcSm61T0tN7Hs/0LasZr2XMGcWZB4ItK2/xi8zZ/7Qfrk5s/dLI+tcIO66VaVtamlpUeanPKdG1qMGAAwbFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPCCAgIAeJHsewGXij89M9seCjCnvKDaHgrts0+AlqSuy+LmzK0fHDdnkmSfflzfkWvOSNL7MfvE6b+22qdhd8YDTBJ39v0QCnWYM5KUl3HKnLlr/IfmzC+PzzJn3v0f9onv+1ommzOS5I42mTOJ9vZA27oUcQYEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8oIAAAF6EnHMBRl4OnFgspmg0qnlarORQiu/l9Ju2/1Zizhy9wb6d5Gz78Ml1X/m/9g1J+s6//ndzpuA39sOtM2r/PikWbPak4qMDPB2CRJLtIZcSYNBsV8ickaRQwp7L+sCeSW21P6aPl7SZM/HuYHOXE82p5sz3vv6qObPt6zPMmfixRnNmsMRdt6q0TS0tLcrMvPCwY86AAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAFxQQAMALhpEOklnvJcyZUz0Rc2bviSJzZmx6uzkjSbOyDpkza8e9H2hbVqcS9qGskvS3RNyc6XD2IZw9ATLtzj5QMy3UY85IUjRsz41PHmPO/KHrtDnzPz9cYs4cPJFjzkhS2r9deJDmhXSPsX9tC/7378yZoYxhpACAIY0CAgB4YS6gnTt36sYbb1RhYaFCoZC2bt3a53bnnB555BEVFBQoPT1dpaWlOnjwYH+tFwAwQpgLqK2tTTNnztT69evPe/u6dev01FNP6ZlnntHu3bs1evRoLVy4UB0dwX4mDwAYmcyvapaVlamsrOy8tznn9OSTT+qhhx7S4sWLJUnPPvus8vLytHXrVt16662fbbUAgBGjX18DamhoUGNjo0pLS3uvi0ajKikpUU1NzXkznZ2disVifS4AgJGvXwuosfHM3yjPy8vrc31eXl7vbWerrKxUNBrtvRQV2d9GDAAYfry/C66iokItLS29l8OHD/teEgBgEPRrAeXn50uSmpqa+lzf1NTUe9vZIpGIMjMz+1wAACNfvxZQcXGx8vPztWPHjt7rYrGYdu/erTlz5vTnpgAAw5z5XXCnTp1SXV1d78cNDQ3at2+fsrOzNWHCBK1evVo//OEPdeWVV6q4uFgPP/ywCgsLtWTJkv5cNwBgmDMX0J49e3TDDTf0frxmzRpJ0rJly7Rp0yY98MADamtr08qVK9Xc3KzrrrtO27dvV1paWv+tGgAw7DGMdJD8+cf2H0HOuq7WnLk19x1z5v53vmnOSFLkQLo50zHOPpR19BH7T4pdkjkiSUrY532qJ93+FAq6PqtQ3D4YU5KS7TNCFe62Z7rt80vVUdRlztSV/R/7hiTdeWieOfPsxJ3mTOnt/2zOJFW9a84MFoaRAgCGNAoIAOAFBQQA8IICAgB4QQEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFBQQA8IICAgB4QQEBALwIMPsXQaRPaTZnPu4YZc78JnaVOTP69/ap1pJ0uqTNnPmnK983ZxLO/n1SJMho5oC6A4y2DvKYwiH7JPFwKNiw+0g4bs7EE/bH9O7fisyZ2C8LzZkfXjPNnJGkdw5PNGemN95uzhS9W3fxO52lx5wYejgDAgB4QQEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFBQQA8IICAgB4QQEBALyggAAAXlBAAAAvGEY6SOZe/mdzJj2py5xZFN1vztQ0zjZnJCl2OsWcOd2Tas78tT1qziSH7YM7Jakzbn9KpCTZx0IGGdzpXMicCQUcRpqTZh802x63Hw9XZzWaM79vtw8jLY4cN2ck6Qv59vVNHnPCnDnwuSnmjPbH7JkhhjMgAIAXFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPCCYaSDJDlsH1j5t67R5kyHsw+ETI3Z1yZJKend5kzc2b/nSQ2w71KT4uaMJIVlH94Z5GsbDyWZM+GQfcBq3Nm3I0kpAR7TmBT7+iJh+zE06qNgX9sgpmY0mTOjAgwRbp+Qac6k2ecODzmcAQEAvKCAAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAFwwjHSQpIftwx3DIPhiz29m/pJETHeaMJKWl24dCdifswzGDDPtMuJA5E1SQbSVkzwT5bvF03D6cVpK6U+xfp/Qk+2DR5LB9gGnakVZz5kTcPuxTkjoTAZ5PYfvzoivT/tVNMyeGHs6AAABeUEAAAC/MBbRz507deOONKiwsVCgU0tatW/vcvnz5coVCoT6XRYsW9dd6AQAjhLmA2traNHPmTK1fv/6C91m0aJGOHTvWe3n++ec/0yIBACOP+RW2srIylZWVfep9IpGI8vPzAy8KADDyDchrQFVVVcrNzdWUKVN0zz336OTJkxe8b2dnp2KxWJ8LAGDk6/cCWrRokZ599lnt2LFDP/7xj1VdXa2ysjL19Jz/rbSVlZWKRqO9l6Kiov5eEgBgCOr33wO69dZbe/89ffp0zZgxQ5MnT1ZVVZXmz59/zv0rKiq0Zs2a3o9jsRglBACXgAF/G/akSZOUk5Ojurq6894eiUSUmZnZ5wIAGPkGvICOHDmikydPqqCgYKA3BQAYRsw/gjt16lSfs5mGhgbt27dP2dnZys7O1mOPPaalS5cqPz9f9fX1euCBB3TFFVdo4cKF/bpwAMDwZi6gPXv26IYbbuj9+JPXb5YtW6YNGzZo//79+sUvfqHm5mYVFhZqwYIF+pd/+RdFIpH+WzUAYNgzF9C8efPk3IWHZP7617/+TAvC3wUaaugCDPs8dNyckaSMtNGBcoMhyCBXSYq7AEMhAwxLTVaATIDBnUkhe0aSugIMjQ1yvAYR6ug0Z8IB90OQfR5kgGkiafCG5w4lzIIDAHhBAQEAvKCAAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAF/3+J7lxfgk3ONNuk2SfAh1vbAq0rbTkCeZMkP0QDzCZOej0484e+1MiOcC2ErLvh0TP4H2/2NGTYs4E2Q9Jsmfc6DRz5k/t+eaMJGUltwfKWfXYH9KIwBkQAMALCggA4AUFBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwggICAHjBMFIEFk09bc7Enf17niCDRZPDwYaRJgUcYmoVaDhtgEhPgP0tSQln3w+n4hFzJiXcY870jE41Z6o+vMKckaTbr9pjzrTE082ZQZpVPORwBgQA8IICAgB4QQEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFBQQA8IICAgB4QQEBALyggAAAXjCMdJAcPn2ZOZOfFjNnUkJxcyaosZF2c6Y1wMDKRICBmvHBmSkqSUoEmBIaDjl7RvZMkGGfUrBhqafjKeZMkMfkwva1dR4ZY85I0qipXebMx26UOeOSzJERgTMgAIAXFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPCCYaQBhNPSzJkgwx1TQvZBknWd+eZMUKOTO82ZtnjqAKzkXEEGmErSqGT78MmuhP1pFGQYaRBpSd2BckEeU0/Cvs+DDHJ1KfbtjD4U7HgYk9RhznQm7ENZEyn2/TAScAYEAPCCAgIAeGEqoMrKSl1zzTXKyMhQbm6ulixZotra2j736ejoUHl5ucaOHasxY8Zo6dKlampq6tdFAwCGP1MBVVdXq7y8XLt27dLrr7+u7u5uLViwQG1tbb33ue+++/Tqq6/q5ZdfVnV1tY4ePaqbb7653xcOABjeTK80bt++vc/HmzZtUm5urvbu3au5c+eqpaVFP/vZz7R582Z9/etflyRt3LhRn//857Vr1y599atf7b+VAwCGtc/0GlBLS4skKTs7W5K0d+9edXd3q7S0tPc+U6dO1YQJE1RTU3Pez9HZ2alYLNbnAgAY+QIXUCKR0OrVq3Xttddq2rRpkqTGxkalpqYqKyurz33z8vLU2Nh43s9TWVmpaDTaeykqKgq6JADAMBK4gMrLy3XgwAG98MILn2kBFRUVamlp6b0cPnz4M30+AMDwEOgXUVetWqXXXntNO3fu1Pjx43uvz8/PV1dXl5qbm/ucBTU1NSk///y/IBmJRBSJRIIsAwAwjJnOgJxzWrVqlbZs2aI333xTxcXFfW6fNWuWUlJStGPHjt7ramtrdejQIc2ZM6d/VgwAGBFMZ0Dl5eXavHmztm3bpoyMjN7XdaLRqNLT0xWNRnXXXXdpzZo1ys7OVmZmpu69917NmTOHd8ABAPowFdCGDRskSfPmzetz/caNG7V8+XJJ0k9+8hOFw2EtXbpUnZ2dWrhwoX7605/2y2IBACOHqYCcu/gAxbS0NK1fv17r168PvKih7h/ZD2cLMow0PcAgyZ0nrzRnpGCTKiLhuDkTZPhkPOBg0SDCAdYXZLBoWPZMkP0Q7wk2bzg5nDBnghzjHQEGd3ZF7Y8puzbYUNbRYfvA3UADVi/NWaTMggMA+EEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXwUblwiwRYJJxSqjHnPljU645MzHgNOwg6wsyMXlUcpc5kxyyT3OWpEiSfcJ3dyIp0LaswgEeU5DjTpK6AjymIFPBg+iI2tc2dl9zoG2lhOzHQ5BJ5wEGaI8InAEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFBQQA8IICAgB4QQEBALyggAAAXlBAAAAvKCAAgBcMIx0kiQDTBoMM++w+MtqcCaq5e5Q5U/e3HHOm9VS6OZPoGbzpjq4nwPdxYfvAylCQYZ8Bd0MoQC4l1T64Myu13ZzpHhNgcXWH7BlJSQEGi3YHGACbuET/J+YMCADgBQUEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8uERH4H02oQCTGsMBhhoGkXJq8IZwZqXYB0mOSu02Z7rS7Ifp+Kxmc0aSOnvs2+rqSTJnBuurFA4ywFRSUjhhzpw4ZR+EW5AWM2d259sfU6KtzZyRpKwkey49yX6MJ1LMkRGBMyAAgBcUEADACwoIAOAFBQQA8IICAgB4QQEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFBQQA8IJhpEGk2CcHtsVTzZn2hD3jBm8WqV7cfp05E8/sMWciJ+zDPhuSMs0ZSQrZlxeIsz+kYF/bgMdDyD6LVKG4fWMvx75szozfO0hfJEltiYg505Ww/7fqLtFTgUv0YQMAfKOAAABemAqosrJS11xzjTIyMpSbm6slS5aotra2z33mzZunUCjU53L33Xf366IBAMOfqYCqq6tVXl6uXbt26fXXX1d3d7cWLFigtrP+2NOKFSt07Nix3su6dev6ddEAgOHP9GrZ9u3b+3y8adMm5ebmau/evZo7d27v9aNGjVJ+fn7/rBAAMCJ9pteAWlpaJEnZ2dl9rn/uueeUk5OjadOmqaKiQu3tF/7TzZ2dnYrFYn0uAICRL/DbsBOJhFavXq1rr71W06ZN673+9ttv18SJE1VYWKj9+/frwQcfVG1trV555ZXzfp7Kyko99thjQZcBABimAhdQeXm5Dhw4oLfffrvP9StXruz99/Tp01VQUKD58+ervr5ekydPPufzVFRUaM2aNb0fx2IxFRUVBV0WAGCYCFRAq1at0muvvaadO3dq/Pjxn3rfkpISSVJdXd15CygSiSgSsf+yFwBgeDMVkHNO9957r7Zs2aKqqioVFxdfNLNv3z5JUkFBQaAFAgBGJlMBlZeXa/Pmzdq2bZsyMjLU2NgoSYpGo0pPT1d9fb02b96sb3zjGxo7dqz279+v++67T3PnztWMGTMG5AEAAIYnUwFt2LBB0plfNv3/bdy4UcuXL1dqaqreeOMNPfnkk2pra1NRUZGWLl2qhx56qN8WDAAYGcw/gvs0RUVFqq6u/kwLAgBcGpiGHUB4zGhzJinAeOGUAKOZu6MBxhgHNOl7NYO2LcCHRIBflQzr079RP5/uqD0zEjCMFADgBQUEAPCCAgIAeEEBAQC8oIAAAF5QQAAALyggAIAXFBAAwAsKCADgBQUEAPCCAgIAeEEBAQC8YBhpAPFjjebMn+qvMWfqjuWaM+N+P4jfU4RCg7Odi0xhBwbKml/fYc5cNvFjcyZn36V5jHMGBADwggICAHhBAQEAvKCAAABeUEAAAC8oIACAFxQQAMALCggA4AUFBADwggICAHhBAQEAvBhys+Dcf879iqtbGkHjkRKnO8yZkOLmTE+XOaK467aHJEnMgsPIFuR529Peac9027cT/Hk78OI6szZ3keduyF3sHoPsyJEjKioq8r0MAMBndPjwYY0fP/6Ctw+5AkokEjp69KgyMjIUOmvaciwWU1FRkQ4fPqzMzExPK/SP/XAG++EM9sMZ7IczhsJ+cM6ptbVVhYWFCocv/ErPkPsRXDgc/tTGlKTMzMxL+gD7BPvhDPbDGeyHM9gPZ/jeD9Fo9KL34U0IAAAvKCAAgBfDqoAikYjWrl2rSCTieylesR/OYD+cwX44g/1wxnDaD0PuTQgAgEvDsDoDAgCMHBQQAMALCggA4AUFBADwYtgU0Pr16/W5z31OaWlpKikp0TvvvON7SYPu0UcfVSgU6nOZOnWq72UNuJ07d+rGG29UYWGhQqGQtm7d2ud255weeeQRFRQUKD09XaWlpTp48KCfxQ6gi+2H5cuXn3N8LFq0yM9iB0hlZaWuueYaZWRkKDc3V0uWLFFtbW2f+3R0dKi8vFxjx47VmDFjtHTpUjU1NXla8cD4R/bDvHnzzjke7r77bk8rPr9hUUAvvvii1qxZo7Vr1+rdd9/VzJkztXDhQh0/ftz30gbd1VdfrWPHjvVe3n77bd9LGnBtbW2aOXOm1q9ff97b161bp6eeekrPPPOMdu/erdGjR2vhwoXq6LAPeBzKLrYfJGnRokV9jo/nn39+EFc48Kqrq1VeXq5du3bp9ddfV3d3txYsWKC2trbe+9x333169dVX9fLLL6u6ulpHjx7VzTff7HHV/e8f2Q+StGLFij7Hw7p16zyt+ALcMDB79mxXXl7e+3FPT48rLCx0lZWVHlc1+NauXetmzpzpexleSXJbtmzp/TiRSLj8/Hz3+OOP917X3NzsIpGIe/755z2scHCcvR+cc27ZsmVu8eLFXtbjy/Hjx50kV11d7Zw787VPSUlxL7/8cu99PvjgAyfJ1dTU+FrmgDt7Pzjn3Ne+9jX37W9/29+i/gFD/gyoq6tLe/fuVWlpae914XBYpaWlqqmp8bgyPw4ePKjCwkJNmjRJd9xxhw4dOuR7SV41NDSosbGxz/ERjUZVUlJySR4fVVVVys3N1ZQpU3TPPffo5MmTvpc0oFpaWiRJ2dnZkqS9e/equ7u7z/EwdepUTZgwYUQfD2fvh08899xzysnJ0bRp01RRUaH29nYfy7ugITeM9GwnTpxQT0+P8vLy+lyfl5enP/7xj55W5UdJSYk2bdqkKVOm6NixY3rsscd0/fXX68CBA8rIyPC9PC8aGxsl6bzHxye3XSoWLVqkm2++WcXFxaqvr9f3v/99lZWVqaamRklJSb6X1+8SiYRWr16ta6+9VtOmTZN05nhITU1VVlZWn/uO5OPhfPtBkm6//XZNnDhRhYWF2r9/vx588EHV1tbqlVde8bjavoZ8AeHvysrKev89Y8YMlZSUaOLEiXrppZd01113eVwZhoJbb72199/Tp0/XjBkzNHnyZFVVVWn+/PkeVzYwysvLdeDAgUviddBPc6H9sHLlyt5/T58+XQUFBZo/f77q6+s1efLkwV7meQ35H8Hl5OQoKSnpnHexNDU1KT8/39OqhoasrCxdddVVqqur870Ubz45Bjg+zjVp0iTl5OSMyONj1apVeu211/TWW2/1+fMt+fn56urqUnNzc5/7j9Tj4UL74XxKSkokaUgdD0O+gFJTUzVr1izt2LGj97pEIqEdO3Zozpw5Hlfm36lTp1RfX6+CggLfS/GmuLhY+fn5fY6PWCym3bt3X/LHx5EjR3Ty5MkRdXw457Rq1Spt2bJFb775poqLi/vcPmvWLKWkpPQ5Hmpra3Xo0KERdTxcbD+cz759+yRpaB0Pvt8F8Y944YUXXCQScZs2bXLvv/++W7lypcvKynKNjY2+lzaovvOd77iqqirX0NDgfvvb37rS0lKXk5Pjjh8/7ntpA6q1tdW999577r333nOS3BNPPOHee+899+GHHzrnnPvRj37ksrKy3LZt29z+/fvd4sWLXXFxsTt9+rTnlfevT9sPra2t7v7773c1NTWuoaHBvfHGG+7LX/6yu/LKK11HR4fvpfebe+65x0WjUVdVVeWOHTvWe2lvb++9z9133+0mTJjg3nzzTbdnzx43Z84cN2fOHI+r7n8X2w91dXXuBz/4gduzZ49raGhw27Ztc5MmTXJz5871vPK+hkUBOefc008/7SZMmOBSU1Pd7Nmz3a5du3wvadDdcsstrqCgwKWmprrLL7/c3XLLLa6urs73sgbcW2+95SSdc1m2bJlz7sxbsR9++GGXl5fnIpGImz9/vqutrfW76AHwafuhvb3dLViwwI0bN86lpKS4iRMnuhUrVoy4b9LO9/gluY0bN/be5/Tp0+5b3/qWu+yyy9yoUaPcTTfd5I4dO+Zv0QPgYvvh0KFDbu7cuS47O9tFIhF3xRVXuO9+97uupaXF78LPwp9jAAB4MeRfAwIAjEwUEADACwoIAOAFBQQA8IICAgB4QQEBALyggAAAXlBAAAAvKCAAgBcUEADACwoIAOAFBQQA8OL/AT7V7neb9RCSAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(train_images[5])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6ef803db-838a-4dfa-b966-650bdc448b84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# normalization\n",
+    "train_images=train_images/255.0\n",
+    "test_images=test_images/255.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b6beb491-9711-40ba-8309-df73c328785b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.00392157 0.         0.         0.05098039 0.28627451 0.\n",
+      "  0.         0.00392157 0.01568627 0.         0.         0.\n",
+      "  0.         0.00392157 0.00392157 0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.01176471 0.         0.14117647 0.53333333 0.49803922 0.24313725\n",
+      "  0.21176471 0.         0.         0.         0.00392157 0.01176471\n",
+      "  0.01568627 0.         0.         0.01176471]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.02352941 0.         0.4        0.8        0.69019608 0.5254902\n",
+      "  0.56470588 0.48235294 0.09019608 0.         0.         0.\n",
+      "  0.         0.04705882 0.03921569 0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.60784314 0.9254902  0.81176471 0.69803922\n",
+      "  0.41960784 0.61176471 0.63137255 0.42745098 0.25098039 0.09019608\n",
+      "  0.30196078 0.50980392 0.28235294 0.05882353]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.00392157\n",
+      "  0.         0.27058824 0.81176471 0.8745098  0.85490196 0.84705882\n",
+      "  0.84705882 0.63921569 0.49803922 0.4745098  0.47843137 0.57254902\n",
+      "  0.55294118 0.34509804 0.6745098  0.25882353]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.00392157 0.00392157 0.00392157\n",
+      "  0.         0.78431373 0.90980392 0.90980392 0.91372549 0.89803922\n",
+      "  0.8745098  0.8745098  0.84313725 0.83529412 0.64313725 0.49803922\n",
+      "  0.48235294 0.76862745 0.89803922 0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.71764706 0.88235294 0.84705882 0.8745098  0.89411765\n",
+      "  0.92156863 0.89019608 0.87843137 0.87058824 0.87843137 0.86666667\n",
+      "  0.8745098  0.96078431 0.67843137 0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.75686275 0.89411765 0.85490196 0.83529412 0.77647059\n",
+      "  0.70588235 0.83137255 0.82352941 0.82745098 0.83529412 0.8745098\n",
+      "  0.8627451  0.95294118 0.79215686 0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.00392157 0.01176471 0.\n",
+      "  0.04705882 0.85882353 0.8627451  0.83137255 0.85490196 0.75294118\n",
+      "  0.6627451  0.89019608 0.81568627 0.85490196 0.87843137 0.83137255\n",
+      "  0.88627451 0.77254902 0.81960784 0.20392157]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.02352941 0.\n",
+      "  0.38823529 0.95686275 0.87058824 0.8627451  0.85490196 0.79607843\n",
+      "  0.77647059 0.86666667 0.84313725 0.83529412 0.87058824 0.8627451\n",
+      "  0.96078431 0.46666667 0.65490196 0.21960784]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.01568627 0.         0.\n",
+      "  0.21568627 0.9254902  0.89411765 0.90196078 0.89411765 0.94117647\n",
+      "  0.90980392 0.83529412 0.85490196 0.8745098  0.91764706 0.85098039\n",
+      "  0.85098039 0.81960784 0.36078431 0.        ]\n",
+      " [0.         0.         0.00392157 0.01568627 0.02352941 0.02745098\n",
+      "  0.00784314 0.         0.         0.         0.         0.\n",
+      "  0.92941176 0.88627451 0.85098039 0.8745098  0.87058824 0.85882353\n",
+      "  0.87058824 0.86666667 0.84705882 0.8745098  0.89803922 0.84313725\n",
+      "  0.85490196 1.         0.30196078 0.        ]\n",
+      " [0.         0.01176471 0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.24313725 0.56862745 0.8\n",
+      "  0.89411765 0.81176471 0.83529412 0.86666667 0.85490196 0.81568627\n",
+      "  0.82745098 0.85490196 0.87843137 0.8745098  0.85882353 0.84313725\n",
+      "  0.87843137 0.95686275 0.62352941 0.        ]\n",
+      " [0.         0.         0.         0.         0.07058824 0.17254902\n",
+      "  0.32156863 0.41960784 0.74117647 0.89411765 0.8627451  0.87058824\n",
+      "  0.85098039 0.88627451 0.78431373 0.80392157 0.82745098 0.90196078\n",
+      "  0.87843137 0.91764706 0.69019608 0.7372549  0.98039216 0.97254902\n",
+      "  0.91372549 0.93333333 0.84313725 0.        ]\n",
+      " [0.         0.22352941 0.73333333 0.81568627 0.87843137 0.86666667\n",
+      "  0.87843137 0.81568627 0.8        0.83921569 0.81568627 0.81960784\n",
+      "  0.78431373 0.62352941 0.96078431 0.75686275 0.80784314 0.8745098\n",
+      "  1.         1.         0.86666667 0.91764706 0.86666667 0.82745098\n",
+      "  0.8627451  0.90980392 0.96470588 0.        ]\n",
+      " [0.01176471 0.79215686 0.89411765 0.87843137 0.86666667 0.82745098\n",
+      "  0.82745098 0.83921569 0.80392157 0.80392157 0.80392157 0.8627451\n",
+      "  0.94117647 0.31372549 0.58823529 1.         0.89803922 0.86666667\n",
+      "  0.7372549  0.60392157 0.74901961 0.82352941 0.8        0.81960784\n",
+      "  0.87058824 0.89411765 0.88235294 0.        ]\n",
+      " [0.38431373 0.91372549 0.77647059 0.82352941 0.87058824 0.89803922\n",
+      "  0.89803922 0.91764706 0.97647059 0.8627451  0.76078431 0.84313725\n",
+      "  0.85098039 0.94509804 0.25490196 0.28627451 0.41568627 0.45882353\n",
+      "  0.65882353 0.85882353 0.86666667 0.84313725 0.85098039 0.8745098\n",
+      "  0.8745098  0.87843137 0.89803922 0.11372549]\n",
+      " [0.29411765 0.8        0.83137255 0.8        0.75686275 0.80392157\n",
+      "  0.82745098 0.88235294 0.84705882 0.7254902  0.77254902 0.80784314\n",
+      "  0.77647059 0.83529412 0.94117647 0.76470588 0.89019608 0.96078431\n",
+      "  0.9372549  0.8745098  0.85490196 0.83137255 0.81960784 0.87058824\n",
+      "  0.8627451  0.86666667 0.90196078 0.2627451 ]\n",
+      " [0.18823529 0.79607843 0.71764706 0.76078431 0.83529412 0.77254902\n",
+      "  0.7254902  0.74509804 0.76078431 0.75294118 0.79215686 0.83921569\n",
+      "  0.85882353 0.86666667 0.8627451  0.9254902  0.88235294 0.84705882\n",
+      "  0.78039216 0.80784314 0.72941176 0.70980392 0.69411765 0.6745098\n",
+      "  0.70980392 0.80392157 0.80784314 0.45098039]\n",
+      " [0.         0.47843137 0.85882353 0.75686275 0.70196078 0.67058824\n",
+      "  0.71764706 0.76862745 0.8        0.82352941 0.83529412 0.81176471\n",
+      "  0.82745098 0.82352941 0.78431373 0.76862745 0.76078431 0.74901961\n",
+      "  0.76470588 0.74901961 0.77647059 0.75294118 0.69019608 0.61176471\n",
+      "  0.65490196 0.69411765 0.82352941 0.36078431]\n",
+      " [0.         0.         0.29019608 0.74117647 0.83137255 0.74901961\n",
+      "  0.68627451 0.6745098  0.68627451 0.70980392 0.7254902  0.7372549\n",
+      "  0.74117647 0.7372549  0.75686275 0.77647059 0.8        0.81960784\n",
+      "  0.82352941 0.82352941 0.82745098 0.7372549  0.7372549  0.76078431\n",
+      "  0.75294118 0.84705882 0.66666667 0.        ]\n",
+      " [0.00784314 0.         0.         0.         0.25882353 0.78431373\n",
+      "  0.87058824 0.92941176 0.9372549  0.94901961 0.96470588 0.95294118\n",
+      "  0.95686275 0.86666667 0.8627451  0.75686275 0.74901961 0.70196078\n",
+      "  0.71372549 0.71372549 0.70980392 0.69019608 0.65098039 0.65882353\n",
+      "  0.38823529 0.22745098 0.         0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.15686275 0.23921569 0.17254902 0.28235294 0.16078431\n",
+      "  0.1372549  0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.        ]\n",
+      " [0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.        ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(train_images[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a8caafc4-52fd-4e3e-9277-305b70a15515",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "W0000 00:00:1770444661.736760    5962 gpu_device.cc:2342] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org/install/gpu for how to download and setup the required libraries for your platform.\n",
+      "Skipping registering GPU devices...\n"
+     ]
+    }
+   ],
+   "source": [
+    "#create a deep learning model\n",
+    "model=tf.keras.Sequential([\n",
+    "    tf.keras.Input(shape=(28,28)),\n",
+    "    tf.keras.layers.Flatten(),\n",
+    "    tf.keras.layers.Dense(512,activation=\"relu\"),\n",
+    "    tf.keras.layers.Dense(256,activation=\"relu\"),\n",
+    "    tf.keras.layers.Dense(128,activation=\"relu\"),\n",
+    "    tf.keras.layers.Dense(64,activation=\"relu\"),\n",
+    "    tf.keras.layers.Dense(32,activation=\"relu\"),\n",
+    "    tf.keras.layers.Dense(10,activation=\"softmax\"),\n",
+    "\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2c6a3b2e-3be4-4272-be70-483ccf57ee7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.compile(optimizer=\"Adam\",loss=\"sparse_categorical_crossentropy\", metrics=['accuracy'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "4359c53e-e9ce-416d-8b54-f9940b520404",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m10s\u001b[0m 4ms/step - accuracy: 0.8181 - loss: 0.5040\n",
+      "Epoch 2/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m7s\u001b[0m 4ms/step - accuracy: 0.8627 - loss: 0.3760\n",
+      "Epoch 3/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m7s\u001b[0m 4ms/step - accuracy: 0.8755 - loss: 0.3371\n",
+      "Epoch 4/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m7s\u001b[0m 4ms/step - accuracy: 0.8837 - loss: 0.3155\n",
+      "Epoch 5/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m7s\u001b[0m 4ms/step - accuracy: 0.8904 - loss: 0.2952\n",
+      "Epoch 6/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m7s\u001b[0m 4ms/step - accuracy: 0.8967 - loss: 0.2802\n",
+      "Epoch 7/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m7s\u001b[0m 4ms/step - accuracy: 0.8999 - loss: 0.2710\n",
+      "Epoch 8/8\n",
+      "\u001b[1m1875/1875\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m7s\u001b[0m 4ms/step - accuracy: 0.9034 - loss: 0.2604\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<keras.src.callbacks.history.History at 0x7b8c1fcdeae0>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(train_images,train_labels,epochs=8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "80fbe731-fed6-4fdf-bead-66086c03a3fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m313/313\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m1s\u001b[0m 2ms/step - accuracy: 0.8804 - loss: 0.3414\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.3413761258125305, 0.8804000020027161]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.evaluate(test_images,test_labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3cfb518c-a6d0-4374-8557-93aba8a91ce2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m313/313\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m0s\u001b[0m 1ms/step\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "predicted_labels=model.predict(test_images)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "52ef5eb8-c948-4714-b8c0-9643320dfb77",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10000\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(len(predicted_labels))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3908a148-1478-48b2-bad4-1472c6406012",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "46e4da97-fe96-409c-8403-710a6763d9bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "Predicted outputs=1 and actual output=1\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAGdCAYAAABU0qcqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAH2pJREFUeJzt3XtwlfW97/HPym1BIFkxhNwkYECFViA9pZJmUIqSAvFsRpTpeDsz4Dgw2uARqdVJj4rankmLM9ajQ/HMmRbqHPG2R+DodtORYEJtAy0IpbQ1JexYwoYEpM2FhFzX7/zBdnUvAelvuZJvEt6vmWeGrPV88nx9eMwnD2vll4BzzgkAgEGWYD0AAODyRAEBAExQQAAAExQQAMAEBQQAMEEBAQBMUEAAABMUEADARJL1AJ8VDod1/PhxpaWlKRAIWI8DAPDknFN7e7vy8/OVkHDx+5whV0DHjx9XQUGB9RgAgC+osbFREyZMuOjzQ66A0tLSJEk36BYlKdl4GgwFuVVjvTNd4diunfaeoHcmlNLlnTlwPN87MzrY5525Ztwp74wknez0P+cpCf3emcSEsHem/782eWcwuPrUqw/0buTr+cUMWAGtX79ezz77rJqamlRUVKQXX3xRs2fPvmTu0392S1KykgIUEKSUsSnemf7+2K6dpGT/AkpO8f8impg6yj8T7PXOJI/xP3eSlBTwPw9Jg1RAAb4uDH3/scLopV5GGZA3Ibz++utas2aN1q5dqw8//FBFRUVauHChTp48ORCHAwAMQwNSQM8995xWrFihe++9V1/+8pf10ksvKTU1VT/72c8G4nAAgGEo7gXU09Ojffv2qbS09O8HSUhQaWmpamtrz9u/u7tbbW1tURsAYOSLewF98skn6u/vV05OTtTjOTk5amo6/8XDyspKhUKhyMY74ADg8mD+g6gVFRVqbW2NbI2NjdYjAQAGQdzfBZeVlaXExEQ1NzdHPd7c3Kzc3Nzz9g8GgwoG/d9xAwAY3uJ+B5SSkqJZs2apqqoq8lg4HFZVVZVKSkrifTgAwDA1ID8HtGbNGi1btkxf+9rXNHv2bD3//PPq6OjQvffeOxCHAwAMQwNSQHfccYdOnTqlJ598Uk1NTfrKV76i7du3n/fGBADA5SvgnHPWQ/xnbW1tCoVCmqdbWQlhBErMGued+f5v/9U78+vOa7wzscpP/pt3Jjngv6zOqb5070yXi+3/oRM9Gd6ZzKQO78ze1knemdNz/M83Blef61W1tqm1tVXp6Re/bs3fBQcAuDxRQAAAExQQAMAEBQQAMEEBAQBMUEAAABMUEADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwMSCrYQMXExiT6p3pV8A7k5rQ7Z2RpNZ+//laYsj8sTPfOxNM8F/AdMqok94ZSQo7/3P+i+Yve2dau0d5Z0JiMdKRgjsgAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJVsPGoPr47gLvTFGK/3H+pW2cf0hSakKPdyY54L9KdUuv/wraSQn93pnsFP/VpiUpNdH/PEwc679Kdc64Nu9M7c2zvTNJO/d5ZzDwuAMCAJiggAAAJiggAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABggsVIMahuu+OX3pmas/4Ld/6uZYJ3RpL+S0ajd6YzHPTOfPOKP3hnmvpC3pnucLJ3RpI+6R3rnTnb73+sG8b+2TuzpfhG78yEnd4RDALugAAAJiggAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJhgMVIMqvsza70zTxwv886MC3Z4ZyQplNTpnUkO9HtnGnszvTOhxLPemdSEHu+MJNV3Zntnjp3J8M70jE/0zpzN8z/fGJq4AwIAmKCAAAAm4l5ATz31lAKBQNQ2bdq0eB8GADDMDchrQNddd5127Njx94Mk8VITACDagDRDUlKScnNzB+JTAwBGiAF5Dejw4cPKz8/X5MmTdc899+jo0aMX3be7u1ttbW1RGwBg5It7ARUXF2vTpk3avn27NmzYoIaGBt14441qb2+/4P6VlZUKhUKRraCgIN4jAQCGoLgXUFlZmb71rW9p5syZWrhwod599121tLTojTfeuOD+FRUVam1tjWyNjY3xHgkAMAQN+LsDMjIydO2116q+vv6CzweDQQWDwYEeAwAwxAz4zwGdOXNGR44cUV5e3kAfCgAwjMS9gB555BHV1NTo448/1q9//WvddtttSkxM1F133RXvQwEAhrG4/xPcsWPHdNddd+n06dMaP368brjhBu3evVvjx4+P96EAAMNY3Avotddei/enxBCVNPkq78yowK+8M3/6a4535kuZzd4ZSep1/otjtvanemf+aezvvTOnwv7H+bgnyzsjSWOSur0zwcQ+78ypvnTvTEI3K4iNFPxNAgBMUEAAABMUEADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwQQEBAExQQAAAExQQAMAEBQQAMDHgv5AOI1f3xEzvzLG+wbnkEuRiyp3s8V8c8ytjjnpn1h5b7J1ZlV/lnZmY/FfvjCQ1JGV7ZxITwt6ZzrD/L6NM9F8nFUMUd0AAABMUEADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwQQEBAExQQAAAExQQAMAEBQQAMEEBAQBMUEAAABOsho2Y/XWa/0rGHS7ZO9PWOco7I/+FuiVJYRfwztw8+i/emZdvKPDO7Do4zTtzX8Ze74wkvd3nf87P9vn/3XY5/y9Bid3+f0cYmrgDAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJCggAYILFSBGz1mudd6axd5x3Jj21yztztt9/YUxJKg41eWd+250d07F8bfp9iXemYt4fYzpWr0v0zqSldHtnws7/e+CEXu8IhijugAAAJiggAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJhgMVLEbMzkVu9MXVeed2Z0sv/qk139sV3a30z9s3dm/vsPeWeu0T7vzMSN/t8vJt4U2/eYwYS+mHK+OsMp3plA/wAMAhPcAQEATFBAAAAT3gW0a9cuLV68WPn5+QoEAtq6dWvU8845Pfnkk8rLy9Po0aNVWlqqw4cPx2teAMAI4V1AHR0dKioq0vr16y/4/Lp16/TCCy/opZde0p49ezRmzBgtXLhQXV3+v1QMADByeb9SW1ZWprKysgs+55zT888/r8cff1y33nqrJOnll19WTk6Otm7dqjvvvPOLTQsAGDHi+hpQQ0ODmpqaVFpaGnksFAqpuLhYtbW1F8x0d3erra0tagMAjHxxLaCmpiZJUk5OTtTjOTk5kec+q7KyUqFQKLIVFBTEcyQAwBBl/i64iooKtba2RrbGxkbrkQAAgyCuBZSbmytJam5ujnq8ubk58txnBYNBpaenR20AgJEvrgVUWFio3NxcVVVVRR5ra2vTnj17VFJSEs9DAQCGOe93wZ05c0b19fWRjxsaGnTgwAFlZmZq4sSJWr16tX7wgx/ommuuUWFhoZ544gnl5+dryZIl8ZwbADDMeRfQ3r17ddNNN0U+XrNmjSRp2bJl2rRpkx599FF1dHRo5cqVamlp0Q033KDt27dr1KhR8ZsaADDseRfQvHnz5Jy76POBQEDPPPOMnnnmmS80GIa+8WM7vDOnetK8M84FvDOjEmNbTDMtwf9YU5/zPw9h74SUvMN/AdNeF9vKnckxrPjZ05/onWntG+2dYTHSkcP8XXAAgMsTBQQAMEEBAQBMUEAAABMUEADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwQQEBAExQQAAAExQQAMCE92rYwKe6+vwvn6Yu/9WwwzGshp09qt07I0k1Z/O8M+GDH8V0rMGwvyeWdbelhMDFV7y/mH9vDXlnpoWaL73TZ/Tzm11GDO6AAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmGAxUsTs1N/8FxYdldQ3AJOcb2LwrzHlHvvtUu/MFO2P6ViDoaZjWky5XpfonTnzyRjvzEehHO+M49vmEYO/SgCACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJCggAYIICAgCYoIAAACZYjBQx6z2T4p3pzEj2zgQT+70z/y30e++MJP3z/1sQU85bgv9inwr7n4ftTdf5H0dSSVaDdybptP+Xk7qkXO+MrhycBW0x8LgDAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJCggAYILFSBG73oB3JD2l2zuTk9rmnUmW/2ySlLH/lHfGf4lQKZDs/7+e6/Y/UkNdnndGkhbl/sE7k9zuf877svwzyS0xLOSKIYk7IACACQoIAGDCu4B27dqlxYsXKz8/X4FAQFu3bo16fvny5QoEAlHbokWL4jUvAGCE8C6gjo4OFRUVaf369RfdZ9GiRTpx4kRke/XVV7/QkACAkcf7ldCysjKVlZV97j7BYFC5uTH8pkMAwGVjQF4Dqq6uVnZ2tqZOnaoHHnhAp0+fvui+3d3damtri9oAACNf3Ato0aJFevnll1VVVaUf/ehHqqmpUVlZmfr7L/wW0srKSoVCochWUFAQ75EAAENQ3H8O6M4774z8ecaMGZo5c6amTJmi6upqzZ8//7z9KyoqtGbNmsjHbW1tlBAAXAYG/G3YkydPVlZWlurr6y/4fDAYVHp6etQGABj5BryAjh07ptOnTysvL7afyAYAjEze/wR35syZqLuZhoYGHThwQJmZmcrMzNTTTz+tpUuXKjc3V0eOHNGjjz6qq6++WgsXLozr4ACA4c27gPbu3aubbrop8vGnr98sW7ZMGzZs0MGDB/Xzn/9cLS0tys/P14IFC/T9739fwWAwflMDAIY97wKaN2+enHMXff4Xv/jFFxoIw0fGH/zfwzKuqMP/OMlnvTMbW6d7ZyQp3NAYU87bRd4VGm8T3w3HlLtr8e+8M/9nzALvTMb4M96ZM3+9wjuDoYm14AAAJiggAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJuL+K7lx+cj537/xzvTdFfLOdIf9L9Org03eGUn659v9V3ROe323/4ECg/O935jfHY8p986Zqd6ZQAwLbyck+If60gdnJXEMPO6AAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmGAxUsTM9fV5Zzr7Urwz+aNb/Y8TDnpnJOnMXf7HSnvd/ziut8c/FIO+Y/8eU+7G1HrvzLqCbu9MVmqnd6alK9M7g6GJOyAAgAkKCABgggICAJiggAAAJiggAIAJCggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmWIwUgypvdJt3Jju53Ttzqi/dOyNJD0193zvzhnJjOtZQNj4x7J255ct/8M6kJ531zvx5VL53BkMTd0AAABMUEADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwQQEBAExQQAAAExQQAMAEBQQAMEEBAQBMsBgpBtWOfdd5Z/7XN/+vd2Z/51XeGUk62p8ZQ8rFdKyh7K32a70z08cc885kJHZ6Z15NKPbOYGjiDggAYIICAgCY8CqgyspKXX/99UpLS1N2draWLFmiurq6qH26urpUXl6ucePGaezYsVq6dKmam5vjOjQAYPjzKqCamhqVl5dr9+7deu+999Tb26sFCxaoo6Mjss/DDz+st99+W2+++aZqamp0/Phx3X777XEfHAAwvHm9CWH79u1RH2/atEnZ2dnat2+f5s6dq9bWVv30pz/V5s2bdfPNN0uSNm7cqC996UvavXu3vv71r8dvcgDAsPaFXgNqbW2VJGVmnnvn0L59+9Tb26vS0tLIPtOmTdPEiRNVW1t7wc/R3d2ttra2qA0AMPLFXEDhcFirV6/WnDlzNH36dElSU1OTUlJSlJGREbVvTk6OmpqaLvh5KisrFQqFIltBQUGsIwEAhpGYC6i8vFyHDh3Sa6+99oUGqKioUGtra2RrbGz8Qp8PADA8xPSDqKtWrdI777yjXbt2acKECZHHc3Nz1dPTo5aWlqi7oObmZuXm5l7wcwWDQQWDwVjGAAAMY153QM45rVq1Slu2bNHOnTtVWFgY9fysWbOUnJysqqqqyGN1dXU6evSoSkpK4jMxAGBE8LoDKi8v1+bNm7Vt2zalpaVFXtcJhUIaPXq0QqGQ7rvvPq1Zs0aZmZlKT0/Xgw8+qJKSEt4BBwCI4lVAGzZskCTNmzcv6vGNGzdq+fLlkqQf//jHSkhI0NKlS9Xd3a2FCxfqJz/5SVyGBQCMHF4F5NylF10cNWqU1q9fr/Xr18c8FEauL/34E+9My82p3plel+idkaRpo094Zw7NnOedCR/8yDszmBq6x3tnCoOnvDOjEnq9M0ktrKE8UrAWHADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwQQEBAExQQAAAExQQAMAEBQQAMEEBAQBMUEAAABMUEADABMvKYlD1H/4378xHZ/O9M1cG/+adkaSMxE7vTPOcK7wz4w96RwZVe98o70zq6G7vTEaC//nuD156VX4MD9wBAQBMUEAAABMUEADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwQQEBAExQQAAAExQQAMAEBQQAMMFipIhdIOCfcf4LSb72qxLvzP+Yv807I0kt/anemcAtp/0PtME/MpiOd4a8Mynp/d6Z5ECfd0YJLEY6UnAHBAAwQQEBAExQQAAAExQQAMAEBQQAMEEBAQBMUEAAABMUEADABAUEADBBAQEATFBAAAATFBAAwASLkSJmgcRE74zr8198cuK/hr0ziaX+GUlq7vVfhPNrOY3emY+9E4Pr+Jl070xm4hnvzIGuSd6ZwBU93hkMTdwBAQBMUEAAABMUEADABAUEADBBAQEATFBAAAATFBAAwAQFBAAwQQEBAExQQAAAExQQAMAEBQQAMMFipIiZ6+8flOME/+W33pmdj0+L6VhTUj/xzsxJP+yd+bcbF3tnEn653zsTq5b20d6Z3KR270x72P84riXFO4OhiTsgAIAJCggAYMKrgCorK3X99dcrLS1N2dnZWrJkierq6qL2mTdvngKBQNR2//33x3VoAMDw51VANTU1Ki8v1+7du/Xee++pt7dXCxYsUEdHR9R+K1as0IkTJyLbunXr4jo0AGD483oTwvbt26M+3rRpk7Kzs7Vv3z7NnTs38nhqaqpyc3PjMyEAYET6Qq8Btba2SpIyMzOjHn/llVeUlZWl6dOnq6KiQp2dnRf9HN3d3Wpra4vaAAAjX8xvww6Hw1q9erXmzJmj6dOnRx6/++67NWnSJOXn5+vgwYN67LHHVFdXp7feeuuCn6eyslJPP/10rGMAAIapmAuovLxchw4d0gcffBD1+MqVKyN/njFjhvLy8jR//nwdOXJEU6ZMOe/zVFRUaM2aNZGP29raVFBQEOtYAIBhIqYCWrVqld555x3t2rVLEyZM+Nx9i4uLJUn19fUXLKBgMKhgMBjLGACAYcyrgJxzevDBB7VlyxZVV1ersLDwkpkDBw5IkvLy8mIaEAAwMnkVUHl5uTZv3qxt27YpLS1NTU1NkqRQKKTRo0fryJEj2rx5s2655RaNGzdOBw8e1MMPP6y5c+dq5syZA/IfAAAYnrwKaMOGDZLO/bDpf7Zx40YtX75cKSkp2rFjh55//nl1dHSooKBAS5cu1eOPPx63gQEAI4P3P8F9noKCAtXU1HyhgQAAlwdWw0bsLvENiaUPT8T2TsrHvvoL70yH8//f6OjCUd6Zq37pHYlZaGyXdyY3MYbV0VNOekeSx5/1Pw6GJBYjBQCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJCggAYILFSDEiTfifseX+acVD3plAb8A7c1V1j3dmUL01zjtSfOq/e2cSWpO9M1e+H/bOYGjiDggAYIICAgCYoIAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJobcWnDOOUlSn3olZzwMhq1Af3dMufDZRP9jxbAWXF9fn/9xXK93Jlb9PV3emfDZGNa36+r3jvT1+q8F1zeI5w7/8fVbf/96fjEBd6k9BtmxY8dUUFBgPQYA4AtqbGzUhAkTLvr8kCugcDis48ePKy0tTYFA9HeWbW1tKigoUGNjo9LT040mtMd5OIfzcA7n4RzOwzlD4Tw459Te3q78/HwlJFz8lZ4h909wCQkJn9uYkpSenn5ZX2Cf4jycw3k4h/NwDufhHOvzEAqFLrkPb0IAAJiggAAAJoZVAQWDQa1du1bBYNB6FFOch3M4D+dwHs7hPJwznM7DkHsTAgDg8jCs7oAAACMHBQQAMEEBAQBMUEAAABPDpoDWr1+vq666SqNGjVJxcbF+85vfWI806J566ikFAoGobdq0adZjDbhdu3Zp8eLFys/PVyAQ0NatW6Oed87pySefVF5enkaPHq3S0lIdPnzYZtgBdKnzsHz58vOuj0WLFtkMO0AqKyt1/fXXKy0tTdnZ2VqyZInq6uqi9unq6lJ5ebnGjRunsWPHaunSpWpubjaaeGD8I+dh3rx5510P999/v9HEFzYsCuj111/XmjVrtHbtWn344YcqKirSwoULdfLkSevRBt11112nEydORLYPPvjAeqQB19HRoaKiIq1fv/6Cz69bt04vvPCCXnrpJe3Zs0djxozRwoUL1dXlv6DmUHap8yBJixYtiro+Xn311UGccODV1NSovLxcu3fv1nvvvafe3l4tWLBAHR0dkX0efvhhvf3223rzzTdVU1Oj48eP6/bbbzecOv7+kfMgSStWrIi6HtatW2c08UW4YWD27NmuvLw88nF/f7/Lz893lZWVhlMNvrVr17qioiLrMUxJclu2bIl8HA6HXW5urnv22Wcjj7W0tLhgMOheffVVgwkHx2fPg3POLVu2zN16660m81g5efKkk+Rqamqcc+f+7pOTk92bb74Z2edPf/qTk+Rqa2utxhxwnz0Pzjn3jW98wz300EN2Q/0DhvwdUE9Pj/bt26fS0tLIYwkJCSotLVVtba3hZDYOHz6s/Px8TZ48Wffcc4+OHj1qPZKphoYGNTU1RV0foVBIxcXFl+X1UV1drezsbE2dOlUPPPCATp8+bT3SgGptbZUkZWZmSpL27dun3t7eqOth2rRpmjhx4oi+Hj57Hj71yiuvKCsrS9OnT1dFRYU6OzstxruoIbcY6Wd98skn6u/vV05OTtTjOTk5+uijj4ymslFcXKxNmzZp6tSpOnHihJ5++mndeOONOnTokNLS0qzHM9HU1CRJF7w+Pn3ucrFo0SLdfvvtKiws1JEjR/S9731PZWVlqq2tVWKi/+85GurC4bBWr16tOXPmaPr06ZLOXQ8pKSnKyMiI2nckXw8XOg+SdPfdd2vSpEnKz8/XwYMH9dhjj6murk5vvfWW4bTRhnwB4e/Kysoif545c6aKi4s1adIkvfHGG7rvvvsMJ8NQcOedd0b+PGPGDM2cOVNTpkxRdXW15s+fbzjZwCgvL9ehQ4cui9dBP8/FzsPKlSsjf54xY4by8vI0f/58HTlyRFOmTBnsMS9oyP8TXFZWlhITE897F0tzc7Nyc3ONphoaMjIydO2116q+vt56FDOfXgNcH+ebPHmysrKyRuT1sWrVKr3zzjt6//33o359S25urnp6etTS0hK1/0i9Hi52Hi6kuLhYkobU9TDkCyglJUWzZs1SVVVV5LFwOKyqqiqVlJQYTmbvzJkzOnLkiPLy8qxHMVNYWKjc3Nyo66OtrU179uy57K+PY8eO6fTp0yPq+nDOadWqVdqyZYt27typwsLCqOdnzZql5OTkqOuhrq5OR48eHVHXw6XOw4UcOHBAkobW9WD9Loh/xGuvveaCwaDbtGmT++Mf/+hWrlzpMjIyXFNTk/Vog+o73/mOq66udg0NDe5Xv/qVKy0tdVlZWe7kyZPWow2o9vZ2t3//frd//34nyT333HNu//797i9/+Ytzzrkf/vCHLiMjw23bts0dPHjQ3Xrrra6wsNCdPXvWePL4+rzz0N7e7h555BFXW1vrGhoa3I4dO9xXv/pVd80117iuri7r0ePmgQcecKFQyFVXV7sTJ05Ets7Ozsg+999/v5s4caLbuXOn27t3ryspKXElJSWGU8ffpc5DfX29e+aZZ9zevXtdQ0OD27Ztm5s8ebKbO3eu8eTRhkUBOefciy++6CZOnOhSUlLc7Nmz3e7du61HGnR33HGHy8vLcykpKe7KK690d9xxh6uvr7cea8C9//77TtJ527Jly5xz596K/cQTT7icnBwXDAbd/PnzXV1dne3QA+DzzkNnZ6dbsGCBGz9+vEtOTnaTJk1yK1asGHHfpF3ov1+S27hxY2Sfs2fPum9/+9vuiiuucKmpqe62225zJ06csBt6AFzqPBw9etTNnTvXZWZmumAw6K6++mr33e9+17W2ttoO/hn8OgYAgIkh/xoQAGBkooAAACYoIACACQoIAGCCAgIAmKCAAAAmKCAAgAkKCABgggICAJiggAAAJiggAIAJCggAYOL/Awj4mNnzSLSWAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# print(test_images[5])\n",
+    "import numpy as np\n",
+    "plt.imshow(test_images[5])\n",
+    "print(test_labels[5]) \n",
+    "print(f\"Predicted outputs={np.argmax(predicted_labels[5])} and actual output={test_labels[5]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "dbb5f665-1390-4e12-a15e-a85876457a60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_pred=np.zeros(len(predicted_labels))\n",
+    "for i in range(len(predicted_labels)):\n",
+    "    y_pred[i]=np.argmax(predicted_labels[i])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "35b02f09-de29-4f61-ad61-12f1716dd172",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# confusion matrix\n",
+    "from sklearn.metrics import confusion_matrix, classification_report, accuracy_score\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "e800ddeb-b69c-4639-9deb-19b347422ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm=confusion_matrix(test_labels,y_pred)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "9c7c8e44-c62d-48e2-ab83-ce19f154fb84",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           0       0.83      0.84      0.83      1000\n",
+      "           1       0.99      0.97      0.98      1000\n",
+      "           2       0.77      0.83      0.80      1000\n",
+      "           3       0.90      0.85      0.87      1000\n",
+      "           4       0.75      0.82      0.78      1000\n",
+      "           5       0.97      0.97      0.97      1000\n",
+      "           6       0.74      0.64      0.69      1000\n",
+      "           7       0.93      0.96      0.94      1000\n",
+      "           8       0.97      0.98      0.97      1000\n",
+      "           9       0.97      0.94      0.96      1000\n",
+      "\n",
+      "    accuracy                           0.88     10000\n",
+      "   macro avg       0.88      0.88      0.88     10000\n",
+      "weighted avg       0.88      0.88      0.88     10000\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "cr=classification_report(test_labels,y_pred)\n",
+    "print(cr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "b10402c1-1b83-42c5-963e-379eed7dfea1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.8804\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(accuracy_score(test_labels,y_pred))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "049f1005-71b9-4db2-bee1-eed8b66d99fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# visulaize confusion matrix\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "5338b407-9f8b-4518-b621-f3f1c75677a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlgAAAHWCAYAAACrNPfpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAraRJREFUeJzs3XV4FFcXwOHf7sbdE9zd3V2Lu5ZCaaGleAsUKhSnWLEKLW2xYqW4O7S4uxXXKBHiye58f+Rjw5KEZMOSzdLzPs88kDszd85OZjdn771zR6UoioIQQgghhDAZtbkDEEIIIYR420iCJYQQQghhYpJgCSGEEEKYmCRYQgghhBAmJgmWEEIIIYSJSYIlhBBCCGFikmAJIYQQQpiYJFhCCCGEECYmCZYQQgghhIlJgiVEKvr06YOTk1OGtlWpVIwbN+7NBiSyXGRkJB9++CF+fn6oVCqGDRtm7pAy5e7du6hUKhYvXmzuUIT4T5EES1iMxYsXo1KpUl1Gjx5t7vCy3Lhx41CpVKjVah48eJBifUREBPb29qhUKgYNGqQvf/4HV6VSsXbt2jTrDQ4ONijfvHkz9erVw8fHBwcHBwoWLEiXLl3YsWNHirpnzpwJQP78+dP8nb24ZMc//lOmTGHx4sUMGDCAZcuW0atXL3OHxLZt2ySZF8JCWJk7ACGMNWHCBAoUKGBQVrp0aTNFAzExMVhZme+tZGtry8qVKxk1apRB+bp169Ldd8KECXTo0AGVSvXK7WbOnMnIkSOpV68eY8aMwcHBgZs3b7Jnzx5WrVpF8+bNU91vzpw5REZG6n/etm0bK1euZPbs2Xh5eenLa9asmW6sWW3fvn1Ur16db775xtyh6G3bto0ffvjBqCQrX758xMTEYG1t/eYCE0KkIAmWsDjvvPMOlStXNncYenZ2dmY9fosWLVJNsFasWEHLli1TbaUCKF++POfOnWP9+vV06NAhzfoTExOZOHEiTZo0YdeuXSnWBwYGprlvu3btDH729/dn5cqVtGvXjvz586f9orKBwMBASpYsae4wMi0xMRGdToeNjY3Zr1Eh/ouki1C8Ne7du8cnn3xCsWLFsLe3x9PTk86dO3P37l2D7RISEhg/fjxFihTBzs4OT09Pateuze7du1PU+ejRI9q1a4eTkxPe3t6MGDECrVZrsE1qY7DOnj3LO++8g4uLC05OTjRq1Ihjx44ZbPO8y/Pw4cN8+umneHt74+joSPv27QkKCsrw6+7Rowfnzp3j2rVr+jJ/f3/27dtHjx490tyvW7duFC1alAkTJqAoSprbBQcHExERQa1atVJd7+Pjk+FYM2v79u3Uq1cPZ2dnXFxcqFKlCitWrDDYZs2aNVSqVAl7e3u8vLx49913efTokcE2z8fWver3euDAAVQqFXfu3GHr1q36bsyXr6MXPe+GXbNmDSVLlsTe3p4aNWpw8eJFAH7++WcKFy6MnZ0d9evXT1HXP//8Q+fOncmbNy+2trbkyZOH4cOHExMTYxD7Dz/8oD/e8wUMu2bnzJlDoUKFsLW15cqVKynGYAUGBuLt7U39+vUNfu83b97E0dGRrl27ZvwXI4RIkyRYwuKEh4cTHBxssACcPHmSI0eO0K1bN+bNm8fHH3/M3r17qV+/PtHR0fr9x40bx/jx42nQoAHff/89X375JXnz5uXMmTMGx9FqtTRr1gxPT09mzpxJvXr1mDVrFr/88ssr47t8+TJ16tTh/PnzjBo1iq+//po7d+5Qv359jh8/nmL7wYMHc/78eb755hsGDBjA5s2bDcZMpadu3brkzp3bIOFYvXo1Tk5OtGzZMs39NBoNX331FefPn2f9+vVpbufj44O9vT2bN2/m6dOnGY7LVBYvXkzLli15+vQpY8aM4dtvv6V8+fIGY78WL15Mly5d0Gg0TJ06lX79+rFu3Tpq165NWFiYQX3p/V5LlCjBsmXL8PLyonz58ixbtoxly5bh7e39yjj/+ecfPvvsM3r37s24ceO4evUqrVq14ocffmDevHl88sknjBw5kqNHj9K3b1+DfdesWUN0dDQDBgxg/vz5NGvWjPnz5/Pee+/pt/noo49o0qQJgD6mZcuWGdSzaNEi5s+fT//+/Zk1axYeHh4p4vTx8eGnn37i4MGDzJ8/HwCdTkefPn1wdnbmxx9/TOc3IoTIEEUIC7Fo0SIFSHVRFEWJjo5Osc/Ro0cVQFm6dKm+rFy5ckrLli1feazevXsrgDJhwgSD8goVKiiVKlUyKAOUb775Rv9zu3btFBsbG+XWrVv6ssePHyvOzs5K3bp1U7yexo0bKzqdTl8+fPhwRaPRKGFhYa+M8ZtvvlEAJSgoSBkxYoRSuHBh/boqVaoo77//vj6+gQMH6tfduXNHAZQZM2YoiYmJSpEiRZRy5crpY3ix3ufGjh2rAIqjo6PyzjvvKJMnT1ZOnz6dIqYX607NjBkzFEC5c+fOK1/bc2FhYYqzs7NSrVo1JSYmxmDd83jj4+MVHx8fpXTp0gbbbNmyRQGUsWPH6suM+b3my5cv3evkOUCxtbU1eF0///yzAih+fn5KRESEvnzMmDEpzkFq1+7UqVMVlUql3Lt3T182cOBAJbWP7efn3cXFRQkMDEx13aJFiwzKu3fvrjg4OCg3btzQ/142bNiQodcrhEiftGAJi/PDDz+we/dugwXA3t5ev01CQgIhISEULlwYNzc3g9YpNzc3Ll++zL///pvusT7++GODn+vUqcPt27fT3F6r1bJr1y7atWtHwYIF9eU5cuSgR48eHDp0iIiICIN9+vfvbzDIvE6dOmi1Wu7du5dufM/16NGDmzdvcvLkSf2/r+oefO7FVqwNGzakud348eNZsWIFFSpUYOfOnXz55ZdUqlSJihUrcvXq1QzHaazdu3fz7NkzRo8enWIc0fNzdurUKQIDA/nkk08MtmnZsiXFixdn69atKeo19veaEY0aNTIYV1atWjUAOnbsiLOzc4ryF4/34rUbFRVFcHAwNWvWRFEUzp49m+EYOnbsmG5L23Pff/89rq6udOrUia+//ppevXrRtm3bDB9LCPFqkmAJi1O1alUaN25ssEDS3Xxjx44lT5482Nra4uXlhbe3N2FhYYSHh+v3nzBhAmFhYRQtWpQyZcowcuRILly4kOI4dnZ2Kf5Yubu7ExoammZsQUFBREdHU6xYsRTrSpQogU6nSzGlQt68eVMcA3jlcV5WoUIFihcvzooVK1i+fDl+fn40bNgwQ/v27NmTwoULpzsWq3v37vzzzz+Ehoaya9cuevTowdmzZ2ndujWxsbEZjtUYt27dAl59l+jzRDS1c168ePEUiWpmfq8Z8fLv0dXVFYA8efKkWv7i8e7fv0+fPn3w8PDQjwurV68egMG1m56X7659FQ8PD+bNm8eFCxdwdXVl3rx5Gd5XCJE+uYtQvDUGDx7MokWLGDZsGDVq1MDV1RWVSkW3bt3Q6XT67erWrcutW7fYuHEju3bt4tdff2X27NksWLCADz/8UL+dRqPJkrjTOs6rkp3U9OjRg59++glnZ2e6du2KWp2x70/PW7H69OnDxo0b093excWFJk2a0KRJE6ytrVmyZAnHjx/XJwTZ3Zv6vaZVb3q/X61WS5MmTXj69Cmff/45xYsXx9HRkUePHtGnTx+Dazc9L7aEZcTOnTuBpGTv4cOHuLm5GbW/ECJt0oIl3hp//fUXvXv3ZtasWXTq1IkmTZqkOsgZkr69v//++6xcuZIHDx5QtmxZk0zg6O3tjYODA9evX0+x7tq1a6jV6hQtGqbSo0cPnjx5wo0bNzLUPfiid999l8KFCzN+/HijErvn02U8efLEqONlVKFChQC4dOlSmtvky5cPINVzfv36df367OrixYvcuHGDWbNm8fnnn9O2bVsaN25Mzpw5U2yb3nxlxtixYwe//voro0aNwtvbm969e5OYmGiy+oX4r5MES7w1NBpNiuRg/vz5KaZVCAkJMfjZycmJwoULExcXZ5IYmjZtysaNGw1uxQ8ICGDFihXUrl0bFxeX1z5OagoVKsScOXOYOnUqVatWNWrf561Y586dY9OmTQbroqOjOXr0aKr7bd++HUi9e84UmjZtirOzM1OnTk3RDfn8d125cmV8fHxYsGCBwe9w+/btXL169ZV3UmYHz1u4Xrx2FUVh7ty5KbZ1dHQESPVLgzHCwsL48MMPqVq1KlOmTOHXX3/lzJkzTJky5bXqFUIkky5C8dZo1aoVy5Ytw9XVlZIlS3L06FH27NmDp6enwXYlS5akfv36VKpUCQ8PD06dOsVff/1l1NQIrzJp0iR2795N7dq1+eSTT7CysuLnn38mLi6O6dOnm+QYaRk6dGim9+3ZsycTJ07k3LlzBuXR0dHUrFmT6tWr07x5c/LkyUNYWBgbNmzgn3/+oV27dlSoUOE1I0+di4sLs2fP5sMPP6RKlSr06NEDd3d3zp8/T3R0NEuWLMHa2ppp06bx/vvvU69ePbp3705AQABz584lf/78DB8+/I3EZirFixenUKFCjBgxgkePHuHi4sLatWtTHRNWqVIlAIYMGUKzZs3QaDR069bN6GMOHTqUkJAQ9uzZg0ajoXnz5nz44YdMmjSJtm3bUq5cudd+XUL810mCJd4ac+fORaPRsHz5cmJjY6lVqxZ79uyhWbNmBtsNGTKETZs2sWvXLuLi4siXLx+TJk1i5MiRJomjVKlS/PPPP4wZM4apU6ei0+moVq0af/zxh/4OsuzIysqKr776ivfff9+g3M3NjYULF7J161YWLVqEv78/Go2GYsWKMWPGDIYMGfJG4/rggw/w8fHh22+/ZeLEiVhbW1O8eHGDxKlPnz44ODjw7bff8vnnn+snbJ02bVq2H1dkbW3N5s2bGTJkCFOnTsXOzo727dszaNCgFIlOhw4dGDx4MKtWreKPP/5AURSjE6xNmzaxdOlSZs2aRfHixfXl3333Hbt376Z3796cPHlSHq0jxGtSKcaOpBVCCCGEEK8kY7CEEEIIIUxMEiwhhBBCCBOTBEsIIYQQwsQkwRJCCCGEMDFJsIQQQgghTEwSLCGEEEIIE5MESwghhBDCxN7KiUaVfaXMHUKmuLbsZe4QjOaks7zJCO0t9LJ/qopNf6NsRquyvGn2qib4mjuETDlhHWDuEIymUUz3bMWsYonXNEBEzOgsPV54fEGT1eVqc9tkdWUlacESQgghhDAxy/wqL4QQQojsS6cxdwRmJwmWEEIIIUxKpbO87l9Tky5CIYQQQggTkxYsIYQQQpiWBd7AYGqSYAkhhBDCpKSLULoIhRBCCCFMTlqwhBBCCGFSKp25IzA/SbCEEEIIYVqSYEkXoRBCCCGEqUkLlhBCCCFMykKfKGRSkmAJIYQQwqRkDJZ0EQohhBBCmJxFJ1harZY5c+bQsGFDypYtS+PGjfnhhx9QlIy1TZ65pVBqYCLtJie+4Uhhx2kd74xLpOzgRFpPTOTgpeT0PkGrMHO9Fi+/9fjmXoZPzlW4ev6NWhP92sft91FFLl4bQGDoCPb9/R6VKud47TpNpVrtXCxZ144zdz7icdxnNG9T2GC9l48Dsxc248ydj7gVOoTlmztQoLCbeYL9vx79y7D1VE/OBX3MuaCPWXOwC/Wa5dOv7/ZBaZbv6si5oI+5FTcUZ1cbM0b7ajlyOvHzolbcejSEx6GfcvhUX8pX9DN3WOnKimu6TB1fJm5oxKr7XdmT+D412+Q1+TFe1mZAcf642Yltkb2Yf6QVxap46dc5u9swaE41Fl3uwNZnvVhxuzMDZ1fD0cX6jcaUnT8/UiPXdDaiU0y3WCiLTrAWLlzIypUrGTt2LNu2bWPEiBH8+uuvLNuf/i8kIlrh88Vaqhd7/cnQjt/Q0fDLtJO0M7cUPvtdR6eaatZ/oaFxORWDFui48Sgpzth4uHIfIiPKE+zfhtDghlhZhePutee14urQqThTpjXk28mHqFNjERcvBLJuU1e8vB1eq15TcXC05vKFIL4YujfV9b+vaUu+Am6832kDTast4+H9CFZv64y9g/l6tv0fRTLjq8O0q7GKdjVXcezAAxb81ZoiJTwAsHOw4u9d9/hp2imzxZgRrm627Nj/LgkJOjq3XUP1Cr/x1eh9hIXFmju0V8qqa9rO0YrbF0KZP/ioSepr+l5hZu1tnub6+p0L8PHMqiybeI6Pq2zi9vmnfLutKW7edgB45nTAM6cDP39+kg/LbWD6B4eo0iwXny2sbZL4UpPdPz9eJtd09qJSTLdYKotOsM6ePUujRo2oX78+uXPnpnnz5tSuXZuL99L/jYxboaNVFRXlC6Zcp9Mp/LxDR6OvEik3JJG2kxLZcSbzHcrL9uuoXVLFB03VFMqhYmgbDSXzwPKDSXU626v4faiG2OgCaBNdSYj3ISK0Oja2Iag1kZk+7qAhVVmy6DzLl13k+rUQhg3eQUxMAr16l810naa0f+ddpo87zI5NN1OsK1jEncrVczJ68B7Onw7g1o1QRg/ag529Fe27ljBDtEn2bb3DgR13uXszjLv/hjHrm6NERyZQvlrSN87F88/x88xTnDvxxGwxZsSwz6rz6GEEg/pv48ypJ9y/G87+PXe5ezvM3KG9UlZd0yd3PGLR2DMc3ng/1fXWNmr6T6/Cqntd2Bz+LvOPtKJcvcy3lHQcXoptv95g55Kb3L8azpxPjhAXnUjz94sAcPdyGOO77OfYlgc8uf2Mc/uf8PvXZ6jeKg9qzZuZMTu7f368TK5pkd2YNcEKDg5m+vTptG/fnho1alCjRg3at2/PjBkzCAoKSnf/ChUqcOzYMe7cuQPAtWvXOH36NHVLvfoDZ+0RHQ+CFQa2TP3l/7JTYeNxHeN6qNnytYbejdSMWqTjxI3MpdLnbivULG4YU62SKs7dTrs+lSoBRQFFl7kuJmtrNeUr+LF/3119maLAgX13qVo1V6bqzEo2NhoA4uKSWwYVBeLjtFSpmdNcYRlQq1W06lwUe0crzh7L3gnVy5q3KszZ0/4sWt6WG/cHcfBYH97rW87cYb1SdrqmB8+rTsnq3kzqeZD+FTby9193mbq1CbkKuxhdl5W1mqIVPTmz97G+TFHgzN4nlKzuk+Z+jq7WREckoNOa/it+djrXGSXXdDajM+FiocyWYJ08eZKiRYsyb948XF1dqVu3LnXr1sXV1ZV58+ZRvHhxTp16dTdL//79adGiBe+88w6lSpWiXbt29O7dm9ZV035ZdwMVvtugY/r7GqxS+eYXn5DUejW5l4Y6JdXk8VbRoYaaNlVVrP4nc7/p4AjwfOlz18tFRXBEWnsk4uJ+itjogihK5hIsTy8HrKzUBAVGGZQHBkbh6+eYqTqz0s3rT3l4L4IxE+vg6maLtbWagZ9VIWceZ3xzOJk1tqKlPLkQMoCrzwYx8fuGfNJlKzevPTVrTMbKX8CNvv0rcPtWKB1b/8nvC8/y7axGdHu3tLlDS1N2uaZ98jjSrE8RJnbdz6VDATy5/Yw1313i0uFAmvUpnH4FL3H1skVjpSY0MMagPDQwBnc/+1T3cfG05d0vy7P11+uZeg3pyS7n2hhyTWcvKp1issVSmW0wy+DBg+ncuTMLFixApTJMdBRF4eOPP2bw4MEcPZr2GIjt27ezadMmJk2aRMGCBblx4wbfffcd7q20dK6tSbG9Vqcw4nctg1upKeCbeivXvSCIiYcP5mkNyhMSoUSe5J8rDktuWdHqID7RsKx1VRXje6SMIX063L0OAArhT2tkYv+3Q2Kijg+6buS7n5txNWAQiYk6/tl3j707bqe4XrLanRuhtK66AmcXW5p3KMz0X5vQo/Fai0qy1GoV5077M3Hs3wBcPB9IiZJevP9heVb9ccnM0WVvBcq4o7FSs/hqR4Nya1sNESFxQFIS9tvF9vp1GisVGms1m8Pe1Zet+PYCK7+9YPTxHZytmby5CfeuhrF0/NlMvoq3j1zTIrsxW4J1/vx5Fi9enOofS5VKxfDhw6lQocIr65g+fTq5c+emc+fO+jIPDw+mr3VPNcGKioVL9+DqAx0TVye1RumUpCbZUgMT+W2wGnvbpHgWfKLB181wf5sXztb6L5Lrv3BXYeZ6HUuHJ5c52SVv6+UCIS+1VgVHKHil6E3Q4e61H41VJCGBzTPdegUQEhxNYqIObx/Db0E+Po4E+EelsVf2cvFsIE2qLsPZxQZrGw1Pg2PY8k8PLpwJMGtcCQk67t0KB+DS2UDKVvalz+DyfDVwn1njMkaAfyTXrgUblN24FkLrdsXMFFH6sss1be9ojTZRx4Cqm1J0z8VEJn3JCn4czUeVNurLa7fPR50O+Zna66C+7NnTpGQsPDgObaIOdx/D1ip3H3tC/Q1bteydrJi6rSkxzxL4puM+tIlv5tt9djnXxpBrOpux4K49UzFbF6Gfnx8nTpxIc/2JEyfw9fV9ZR2xsbE0b96c8PBw/TJ27FjcnVNvOXKyg01faVj/RfLSrY6KAr5JCVPZAioK5UhKpJ6EKuTzURksOTySk8EXy33cQKM2LPN0Sd62fEEVR68bfhAeuaZQvmDyNgla5f/JVQRPA5uj6Ox4HQkJOs6d9ad+g/z6MpUK6jXIx4kTj16r7qz2LCKep8ExFCjsRrlKvuzcnHJQvDmpVSr9mDFLcfzoI4oU9TAoK1TEg4f30+y3Nrvsck3/ey4EjZUaNx97Ht96ZrCEBiQlRDqtYlAeFhhLfEyiQdmz0HgAEhN03DgTQsWGybfmq1RQoWEOrhwL1Jc5OFszbUczEuO1fN1uDwlxhq3sppRdzrUx5JrOXuQuQjO2YI0YMYL+/ftz+vRpGjVqpE+mAgIC2Lt3LwsXLmTmzJmvrKNBgwb8+uuv5M2bl8KFC3P16lVWrlxJxyrJicusDVoCw2BaHw1qtYqiL40b9HAGW2somit5n76NVUxdo0Ong0qFVTyLSZpqwckO2tcwPift1UDNe99p+X2PjvqlVWw9pePyPZjQI6muBK3C0F90WNsE8zSoCaBDrU6aA0unswUy98f7+3knWLCwFWdPP+HUqSd8MqgyDg42/LHU+G6JN8HB0ZoChdz0P+fJ70Kpst6Ehcby6MEzWnUoSkhwNI8ePKNEaS8mzGzAjk03ObjnntliHjGxJgd33uXxg2c4OtnQplsxqtXLTZ9WGwDw8nXA29eBfP9/XcVKexH1LJ7HD54RHhpntrhf9uO8k+w88C6fjqrO+r+uUalKDnp/UI7hA3eaO7RXyqpr2s7RymDAeo4CThQq58Gzp3E8+jeCPctv8fmiOvw88iQ3z4Xg6m1HxYY5uH0xlOPbHhp9vLWzLzNqUW2unw7h+skgOgwphZ2jFTsW/ws8T66aYmtvxdT3/sbBxQaH/4cXHhSL7g2MU8nunx8vk2taZDdmS7AGDhyIl5cXs2fP5scff0SrTfo2ptFoqFSpEosXL6ZLly6vrOOrr75i7ty5jB8/npCQEHx8fOjatSuflFqo3yYoHB4/Ne7DZ2gbNR7OCr/s1PFwOTjbQ8m8Kj5qnrkGv4qFVMzsq2bOJh2zN0J+b/j+Y7U+qQsIg30XFDRW0Xjn2Giwb0hAc+LjMjfp3Lq/ruHl5cAXY+vg6+vIxQuBdGy7mqDA15/A1BTKVfJl7e6u+p/Hz2gAwOqllxjebye+ORwZN70+Xr4OBD6JYs3yy8yZcsxc4QLg6e3AzN+a4Z3DgcjweK5dCqZPqw0c3pt0O3+PfmUY+nV1/far9yV1X4/6cBdrl101S8ypOXvan15d1jN2Yj1GflGLe3fD+WLkPtasumLu0F4pq67pYpW9mLX3Hf3PA2ZVA2Dnkn+Z8cEhZnzwDz2/LMdHM6rglcuB8OA4rh4P4thW45MrgANr7uDqbUefcRVw97Pn1vmnjGm5i7DApDmcilT0pES1pDsKl93oZLBvz0JrCLiX+elc0pLdPz9eJtd0NiNdhKiUjE57/gYlJCQQHJzUd+7l5YW19evNTqzsK2WKsLKca8te5g7BaE66NzuT9Jtgb6GP4Hyqyt4TJqZGa4Ht+1UTXj00Ibs6YW3esYmZoVHMe8NKZljiNQ0QETM6S48Xf7uoyeqyKXjDZHVlpWzxl8ba2pocOd6CRwMIIYQQQpBNEiwhhBBCvEXM3zlmdpJgCSGEEMKkVDIGy7KfRSiEEEIIkR1JC5YQQgghTEtasCTBEkIIIYRpWejNliYlXYRCCCGEECYmLVhCCCGEMC3pIpQESwghhBAmJgmWdBEKIYQQQpiatGAJIYQQwqRUFvgYJFOTBEsIIYQQpiVdhNJFKIQQQghhatKCJYQQQgjTkhastzPBcm3Zy9whZMqD8F/MHYLR8rj2N3cIxrPQN75WZu7LEiesA8wdwn+GXNNvMfnVShehEEIIIYSpvZUtWEIIIYQwH5VO7iKUBEsIIYQQpiVdhNJFKIQQQghhatKCJYQQQgjTki5CSbCEEEIIYWIWere2KUkXoRBCCCGEiUkLlhBCCCFMSwa5S4IlhBBCCBOTMVjSRSiEEEIIYWrSgiWEEEII01KkBUsSLCGEEEKYlEruIpQuwoz4dER1DhzqzaPA4dy6N5gVf3agcBGPTNenUiXg4nYc75x/4pd7KZ6+W7C2CUpz+/FfaqhaxjrF0rXdm82P9+xU0bm1FbUrWdG9vRWH/07+RpKYAPO/U+Pltx7f3MvwybkKV8+/UWuiX+uYNWvlYfVfnbh+eyARMaNp2brI674Mk6tWOxdL1rXjzJ2PeBz3Gc3bFDZY7+BozeQ5DTl1qz+3woZw4FwfevUra6ZoU2fqazor9fuoIhevDSAwdAT7/n6PSpVzmDukV5JznXUs4fMjNZZ2nkXGmD3Bio+P588//2T48OF0796d7t27M3z4cNasWUN8fLy5wwOgdp28/LLgDI3qLaNtq9VYW6nZsKUrDg7WmarP1eMQNnaPCQ+pS5B/O+Jic+Hhs5PAgNS3/2y0lm37E/TL5t0JuLgqNGqa+a8Ip0+qaNss7QTtwjkVX3+uoU0HHcvWJFKvoY6RQzXc+jdpfWwsXL+qIjKiPMH+bQgNboiVVTjuXnsyHROAo6M1ly4G8Nmw3a9Vz5vk4GjN5QtBfDF0b6rrx82oT/2m+Rn8/jbqlVvMwvmnmTynEU1bFcriSNNm6ms6q3ToVJwp0xry7eRD1KmxiIsXAlm3qSte3g7mDi1Ncq6zjiV8frzMEs9zhuhUplsslEpRFLPdTHnz5k2aNWvG48ePqVatGr6+vgAEBARw/PhxcufOzfbt2ylcuHA6NRlysf/2TYSr5+llz50HQ2neeDlHDj8wbmdVIn65/yA0qBFxsXn0xV5+m+g/MJABQ9JPmg7sVfH5cA0bdiSSI2dSmU4HS39Xs/4vNU+DIU8++OAjLY2apv7rPX1SxYSvNGzcmZjq+i9GaIiJgdk/aPVlfXtqKFJMYczY5BjzuPbX/9/aJggvvy0EPOqMTuuU7utIT0TMaLp3WcvWzf++dl0vctKZ7g/b47jP6Nt5Izs23dSX7TvTm01rrjNn6jF92Y6j77Jv5x2mjzuc6WNFqhNeK9ZXea1rOgvt+/s9zpx+wojhSX9AVSq4enMgP/90mtkzj6Wzd/Yg5zprvKnPD1PLqvMcETPaZHVlhLKvlMnqUjW8bLK6spJZW7AGDBhAmTJlCAgI4MCBA6xevZrVq1dz4MABAgICKFWqFAMHDjRniKlydbEFIDQ0xuh9VSioVAqKojEoV3Qazp/NWKa+ab2aqtUVfXIFsPhXNds2qRn9tZZV6xPp0UvLN2M0nDmZuez/4nkVVasbJmfVaypcPJ/2JaNSJaAooOhsMnXMt8WpY49p2qoQfjmTksya9fJQsIg7B/fcNW9gr/A613RWsbZWU76CH/v33dWXKQoc2HeXqlVzmS8wI8m5Fs/JeX67mXWQ++HDhzlx4gQuLi4p1rm4uDBx4kSqVatmhsjSplLBtzMac/TIA65eCTZ6f0WxJj7OGyfX84SFuKHT2mHvcAdr2yCCg9NPhoIC4eghFRO+TW5Zio9PSrC+/0VL2fJJSVGuPArnziqsW6OmYhVtWtWlKSQYPDwNEywPT3ia5ktOxMX9FLHRBVGU/3aC9dWwfUz/sQln7nxEQoIWnU5h5IDdHD/0yNyhpep1r+ms4unlgJWVmqDAKIPywMAoihbzNFNUxpFzLV70Vp9nC+7aMxWzJlhubm7cvXuX0qVLp7r+7t27uLm5vbKOuLg44uLiDMoUJRGV6s28tFlzmlKilDfNGv2R6TrCQuri6nEI31yrURQVCfGexEYXQK26le6+WzepcXKG+o2Sk58H9yE2RsXg/oatYgkJUKxE8nb1qiafE50uKTF7sax5K51B91/G6XD3OgAohD+tkYn93y59B1agUrUc9O6wnof3IqheJzdT5jYi4Ekk/+y7b+7wUjDFNS0yRs61+M+QaRrMm2B9+OGHvPfee3z99dc0atTIYAzW3r17mTRpEoMHD35lHVOnTmX8+PEGZTaaRthaNzZ5vDNnN6F5i8K803g5jx89y3Q92kQXnga2QKVKQKVKQKdzwM1zP7lyv3o4nKLA5vVq3mmlw/qFYUQx0UkX8uwftHj7GtZh80Jj0h9/JY+3unxBxfezNfy0KLnM0TF5W08veBqi4sXnHTwNAQ+vl6PS4e61H41VJCGBzf/zrVd2dlaMnlCbD7psZO/2OwBcvRRMqbI+fDy8crZLsEx1TWeFkOBoEhN1ePs4GpT7+DgS4B+Vxl7Zh5xr8TI5z283s47BmjBhAp9//jkzZsygfPny5MyZk5w5c1K+fHlmzJjB559/zrhx415Zx5gxYwgPDzdYbKzqmzzWmbOb0KpNUVo3X8m9e+EmqVNRrNHpHFCp4rC1f0zdBq9uPTpzSsWD+yradjDcrkAhBRsbBX9/yJPXcPH1S97uxXJvX9BYGZZ5vNAiXaacwsnjht9Ajh9VUaZc8rETE/h/chXB08DmKDq7zJ+Mt4SVtRobGw06nWGiq9XpUKuz1ze6N3FNv0kJCTrOnfWnfoP8+jKVCuo1yMeJE9mz+/U5OdciNW/1edaZcLFQZp9o9PPPP+fzzz/nzp07+Pv7A+Dn50eBAgUytL+trS22trYGZabuHvxuTlM6dS1J985reRYZj49v0reNiPA4YmNTvwvvVWzsHqFCITHBFY11BC5up0hMcKV1u6RvLD/MURMYqGL8FMOxU5vWqSldVkehl6Z2cXSEnr11zJ6uQafTUr6iQuQzOH9WjaOTQqu2xt8o2u1dHR+9r2H5EjW16ujYtUPN1csqvvgmKabEBBj9qQZrm2CeBjUBdKjVSXNg6XS2gCbtyl/B0dGagoXc9T/nz+9GmbI+hIbG8vBBRKbqNDUHR2sKFHLT/5wnvwulynoTFhrLowfPOHLwAV9PrUdsTCIP70dQo04eOvUsyfhRB80X9EtMfU1nle/nnWDBwlacPf2EU6ee8Mmgyjg42PDH0gvmDi1Ncq6zjiV8frzMEs9zhkgXoXmnaUjPgwcP+Oabb/j999+N2s/U0zSkdXvrx/22suKPi0bXZ+dwB2fX02isotDpbImNzsezsErcD1sMJE0s+uQxLFiUnGBFPoN3Glrx2eda2nVK+StTFFi9XM3a1WoePQRnl6TxV30+1FGxcsrt05umAZImGl3wvYYnj5KmfRg8XEutukl1PX4E7ZqnPt1BSEBz4uMyN1Fe7Tp52barR4ry5csuMqD/1kzV+bLXnaahRt3crN3dNUX56qWXGN5vJ96+DnwxsQ51G+fDzcOOR/ef8cdvF/hl7unXOq4pp2kw9TWdlfp/XJEhw6vh6+vIxQuBjPpsN6dOPjF3WGmSc511suLz403IivOc5dM07DDd5Mqq5paZbGbrBOv8+fNUrFgRrda4u+De9DxYb8qD8F/MHYLRXpwHy1KYch6srPQm58ESQrzdsjrB0m0rZ7K61C3Om6yurGTWLsJNmza9cv3t27ezKBIhhBBCmIx0EZo3wWrXrh0qlYpXNaKpVPJLEkIIIYRlMetdhDly5GDdunXodLpUlzNnzpgzPCGEEEJkhpnuItRqtXz99dcUKFAAe3t7ChUqxMSJEw0achRFYezYseTIkQN7e3saN27Mv/8aPlLp6dOn9OzZExcXF9zc3Pjggw+IjIw0KhazJliVKlXi9Om0B/6m17olhBBCiGxIUZluMcK0adP46aef+P7777l69SrTpk1j+vTpzJ8/X7/N9OnTmTdvHgsWLOD48eM4OjrSrFkzYmNj9dv07NmTy5cvs3v3brZs2cLff/9N//7GjTk2axfhyJEjiYpKezK1woULs3///iyMSAghhBCW6siRI7Rt25aWLVsCkD9/flauXMmJEyeApNarOXPm8NVXX9G2bVsAli5diq+vLxs2bKBbt25cvXqVHTt2cPLkSSpXrgzA/PnzadGiBTNnziRnzpypH/wlZm3BqlOnDs2bN09zvaOjI/Xq1cvCiIQQQgjx2nQq0y1GqFmzJnv37uXGjRtA0mwEhw4d4p133gHQz7nZuHHy015cXV2pVq0aR48eBeDo0aO4ubnpkyuAxo0bo1arOX78eIZjMftEo0IIIYR4y5jwLsLUnjmc2iTjAKNHjyYiIoLixYuj0WjQarVMnjyZnj17AugnNH/+aL7nfH199ev8/f3x8fExWG9lZYWHh4d+m4wwawuWEEIIIcSrTJ06FVdXV4Nl6tSpqW77559/snz5clasWMGZM2dYsmQJM2fOZMmSJVkctbRgCSGEEMLUjOzae5UxY8bw6aefGpSl1noFSWO7R48eTbdu3QAoU6YM9+7dY+rUqfTu3Rs/v6QH9AYEBJAjR/ITRwICAihfvjyQ9Li+wMBAg3oTExN5+vSpfv+MkBYsIYQQQpiWYrrF1tYWFxcXgyWtBCs6Ohq12jC10Wg06HRJ8z0UKFAAPz8/9u7dq18fERHB8ePHqVGjBgA1atQgLCzMYJaDffv2odPpqFatWoZPgbRgCSGEEOKt0Lp1ayZPnkzevHkpVaoUZ8+e5bvvvqNv375A0vRPw4YNY9KkSRQpUoQCBQrw9ddfkzNnTtq1awdAiRIlaN68Of369WPBggUkJCQwaNAgunXrluE7CEESLCGEEEKYmGLCLkJjzJ8/n6+//ppPPvmEwMBAcubMyUcffcTYsWP124waNYqoqCj69+9PWFgYtWvXZseOHdjZ2em3Wb58OYMGDaJRo0ao1Wo6duzIvHnzjIolWz/sObPkYc9ZRx72nHXkYc9CiMzK6oc9a1dXNVldmq4nTFZXVpIxWEIIIYQQJvZWdhHaKxpzh5ApltgaFL75D3OHYDS/Vr3NHUKmVEj0NncIRjtrFWTuEIyWR+tk7hAy5YHGuOekCfFGmamLMDt5KxMsIYQQQpiRCScatVTSRSiEEEIIYWLSgiWEEEII05IuQkmwhBBCCGFab9/8BMaTLkIhhBBCCBOTFiwhhBBCmJYMcpcESwghhBAmJmOwpItQCCGEEMLUpAVLCCGEECalSBehJFhCCCGEMDHpIpQuQiGEEEIIU5MWLCGEEEKYlnQRSoKVmuq1czNweBXKVvDDL6cTfTqvZ/vmm/r1I76qSbvOxcmV25n4eB0XzgYw9Zt/OHPyiRmjNvTpiOq0aVeMIkU9iI1J5PjxR4z98gA3/32ayRp1OLmew97xFhp1DFqtAzFRhVEUBZUq/TfSmVs6es3RUiQHbPjCOpMxZMyOMzrmbtHyKATy+cCIthrqlU5qrE3QKti5ncDa/gFqq2coOhsSY3MSE1YFReuYofpfdX1YWakZPa42jZsXJF8BVyLC4/l7/z0mfXWQgCdRb+w1v4paraLP2Ao07VEYDz97gh9Hs2Ppvyydck6/jbuPHR9NrUKVxrlwcrPl/D/+zB12lEc3I8wSc1pq1srD0OHVKF/Rlxw5nOneZS1bN/9r7rDS9OHIigyfXJNl887x7YhD5MznzO5/U3/Y+PDu29m19lYWR/hq/T6qyJDh1fD1deTSxUBGfrqb06eyz+fcyyzt+njO0s5zRsgYLOkiTJWDgzWXLwYxetieVNff/jeUL4bvpX7lxbRpuIIH98JZvaUznl72WRxp2mrXycsvC87QqN4y2rZajbWVmg1buuLgkLnkxtHlIo5O14h4Wp2gJ+15FlYZR5eLLDugS3ffiGiFz5dqqV7s9d9wx2/oaPh1Qprrz9zW8dkiLZ1qqFk/xorGZdUM+kXLjcdJ0wrHxoPGJpjY8Ao8e9KOqKDGqK3DcfTeneEYXnV92DtYUbaCL99NPUrj6kvp220DhYu4s/SvDsa/WBPpMbIsbT8qwZyhR3mvzFp+/uIk3UeUoeOgkvptJq9tQs4CLnzZcQ8fVtlAwP1IvtvxDnYO2es7mKOjNZcuBvDZsIz/vsyldCUfOn9YmusXgvVl/g8iqZfnd4Pl+/HHiXoWz6Ed980YbUodOhVnyrSGfDv5EHVqLOLihUDWbeqKl7eDuUNLkyVdH89Z4nkWGZO9Pj2ziX277rBv1500169bfdXg57Gj9tPz/bKULOPNP/uzx4dkh7Z/Gvz8cf+t3HkwlPIV/Dhy+IHR9dnYBhIbk5e42DwAaGOcsYu9zcV76b/ecau0tKqsRq2GvecNn5+g0yks3K3jz8M6giMgvw8MaK6hecXM5f7L9uuoXVLFB000AAxtreHINYXlB3WM767B2V5FVGALg31intbEOcdGVJpIFK1Tusd41fXxLCKeLi3XGJSNGb6XnYd7kSuPM48ePMvU63odpWr4cHjzPY5tT/q9+9+LpFHXghSv4g1A7iIulKruQ+9ya7l7JQyA7wYeZv3DHjTqVpCtv9/I8pjTsnvXbXbvum3uMNLl4GjNtKVN+WbAPj4aU0VfrtMpBAdEG2zbqG1Bdvx1k+iotL84mMOgIVVZsug8y5ddBGDY4B00e6cQvXqXZfbMY2aOLnWWcn28yBLPc4ak/937rSctWK/J2lpNrw/KER4Wy+ULQeYOJ02uLrYAhIbGZGr/+DgfbOyeoLEKB8DK+ik2tgHULfnqS2jtUR0PgmFgi9S3+2WXjo3HdYzrpmHLV1b0bqBh1BItJ/7N3Lvz3B2Fmi+1lNUqoeLcnbTrU6njURRQdDaZOmZ6XFxt0ekUwsPi3kj96bl8NJCKDXKSu4gLAIXKelCmlh/HdzwEwMY2KRmNj9Xq91EUSIjTUqaWb9YH/Bb4al49/t52l2P7Hr5yu5IVvClR3pt1i65kUWQZY22tpnwFP/bvu6svUxQ4sO8uVavmMl9gb5m3+jwrKtMtFkpasDKpyTsF+XlZa+wdrAl4EkmXlmt4GpK55OVNU6ng2xmNOXrkAVevBKe/QyqiIsqiViXgnWMdoAIUnoVXonXVC2nuczdQ4buNWv4YboWVJuWbJD5B4eedOn4frKFCwaQELI+XijO3daw+pKNqEePz/+AI8HQxPJaXS1J56hKxcztBQnQhUEyfYNnaavhqUl3W/3mVyGfxJq8/I5ZPP4+DizXLLnVCp1VQa1T8+vUp9qxMGu9z71oY/vci6T+pMjM/OUxsVCKdh5bGJ48Tnn7STWGsd7oUoUQFb7rW+DPdbTu+X5JbV59y7ph/FkSWcZ5eDlhZqQkKNBw3GBgYRdFinmaK6u0j5/ntJglWJh0++ICGVZfg6WXPu33LsnB5a96ps5zgoOj0d85is+Y0pUQpb5o1+iPTddg53MHe8RZhIfVITHDD2vopLu4nWH9MR/vqKRMhrU5hxCItg1uqKeCb+jeQe0EQEw8fzNcCya0nCVookTt5n4rDk7tOtArEJxqWta6qZnx3TSZelQ5H730ARIfUysT+r2ZlpWbh8jaoVCpGDTbfmJAGnQvSpHshJvY6wN0roRQu58mgWdUIfhLNzmU30SYqfN1lD6N+qcPWoF4kJuo4vfcxx7Y/IAP3L4gX+OV2YvSsOvRrsZH4OO0rt7W109CiW1EWTDmZRdEJkXUUmQdLEqzMio5O4O7tMO7eDuP0iSccvfQhPfqUYd6M4+YOzcDM2U1o3qIw7zRezuNHmR//4+J2ksiIssRGFwQgMcEDjVUkv+w6m2qCFRULl+4rXH2oMPHPpO45nZLU/F1qcAK/DdJg//8GowWfaPB1NXwz2rwwFn/9mOTL9MJdhZkbtSwdmlzm9MK9BV4uEBJhOM4rOCKp3JAOB++9qK0iiQxoYfLWq+fJVe68LnRsvtpsrVcAA76twvIZF9j3Z9LYlNuXQvHN60TPUeXYuSzp7scbZ0L4sPIGHF2ssbLREB4cy0+HW3P9dOZaPP+rSlb0xsvXgTXHu+rLrKzUVK6Tk+6flKWC00/odEnXZ9OOhbF3sGLTH9fMFW6aQoKjSUzU4e1jeGetj48jAf7muRv2bfRWn2cL7tozFUmwTEStVunHsmQXM2c3oVWborRsuoJ798Jfqy6VSktS12AyBTU6JfXtnexg05eGl9fKv3Ucu6Fj7odW5PZMSrhsrODJU6haJO03Yz6f5HX+YQoatWHZi8oXUHH0ukLvhsllR64plC/wYhKYlFxprCKIDGiBorNL89iZ8Ty5KljYjQ7NVhP6NNak9RvL1sEK5aVflE6rQ61OeQ6jIhKABHIVdqFYJS9+++ZMFkX5dji27yFtK6wwKJu8sBG3r4fy28wz+uQKoEOfkuzfcofQYPNeH6lJSNBx7qw/9Rvk109zoFJBvQb5+GWBXBOmIuf57SYJViocHK0pUMhd/3Pe/K6UKutDWGgMoSGxDBtdnZ1bbhLgH4WHpz19P66AX04nNq+9bsaoDX03pymdupake+e1PIuMx8c36RtSRHgcsbGJRtcXG5MHJ5fzaBMdSUxww8rmKY7Ol2hSLjlxmbVRS2CYwrTeVqjVKormNKzDwxlsraBozuQ/7H0bq5m6VotOgUqFVDyLSZpqwclOlWrLWHp6NVDz3mwtv+/RUr+0mq2ndVy+rzChR1Lym6BVcPTeg8YmhMjApoCCSp3UravobIH0k+RXXR8BT6L4bWUbylTw5d3261Br1Hj//9yHPY0hISHrb605svU+744uT8D9KO5eCaVIeU+6DCvNtsXJ8wPV75ifsKBYAh5EUbC0O4O/q86hjfc4tedRlsf7Ko6O1hR84dznz+9GmbI+hIbG8vCB+efsio5M4OZlw7nmoqMSCQ+JNSjPW8iVynVyMqDN5qwOMcO+n3eCBQtbcfb0E06desIngyrj4GDDH0vTHndpbtn9+kiNJZ7njJB5sCTBSlX5Sn6s39VN//OEGUnNIauWXWLUoF0ULupBl5Vt8fCyJzQklnOnn9C20UquXw0xV8gpfPhRRQC27+5pUP5xv62s+OOi0fVFhFbH2fUMLh5H0ahj0WodiI4sxpBWyXc/BYUrPA41rt6hrdR4OMEvu7Q8DAZneyiZR8VHzTL35qxYUM3M92HOZi2zN+vI7w3f99fok7qAMLB2SJpawiXneoN9I/1bkBiX8+UqU3jV9TFz0mGaty4CwP6TfQz2a990FUf+Nn6KjNc1d+gxPhhfkeHza+LuY0fw42g2LbzOkkln9dt45nBg4IxquPvaE/Ikhp1//MvSyeeyPNb0VKiYg227euh/njq9EQDLl11kQP+t5grLaO37lCDgYSSHd2ePaV1Ss+6va3h5OfDF2Dr4+jpy8UIgHduuJigw+40zfc4Srw9LPM8ZImOwUCmKkkYnj+XytZth7hAyJUb16kGx2VH45swPnDcXv1apz6Sd3RXXepg7BKOdtcq+U5ekJU8G5kLLjh5oIs0dgsjGImJGZ+nxYuc1NllddkNSn/Q7u5MWLCGEEEKYlnQRSoIlhBBCCNN6+/rGjCczuQshhBBCmJi0YAkhhBDCtGSQuyRYQgghhDAtmaZBugiFEEIIIUxOWrCEEEIIYVrSgiUJlhBCCCFMSx72LF2EQgghhBAmJy1YQgghhDAt6SKUBEsIIYQQpiV3EUoXoRBCCCGEyUkLlhBCCCFMSwa5S4IlhBBCCNOSZxFKF6EQQgghhMm9lS1Ytoplvqx4dOYOwWjerd4zdwhGC9q5yNwhZEr9xp+ZO4T/hFBVnLlD+M/QWOBAaK1KmmYyQga5v6UJlhBCCCHMSMZgSRehEEIIIYSpSQuWEEIIIUxKugglwRJCCCGEqUmCJV2EQgghhBCmJi1YQgghhDAp6SKUBEsIIYQQpiZ3EUoXoRBCCCGEqUkLlhBCCCFMSh6VIwmWEEIIIUxMxmBJF6EQQgghhMlJC5YQQgghTEtasCTBetnAkVVo3q4whYp5EBuTyOljj5n65SFu3wjVb7N6Vydq1MtjsN8fCy/wxaC9WR1ums5f/5i8+VxTlP+64Awjh+02Q0Qp1aidm0HDq1Kugh9+OZ3o1Xkd2zff1K9v2bYIffqVp1wFPzw87alfdTGXLgQacQQd9q5nsXW6iVodg07rQFxUERRFQaVK/c1//LpC71kpH7r9zww13q5v7gNjxymFuRt1PAqBfD4woqOaemWSjpeQqDB3o0Jw7t/RWoWj0tlgE5Mf56d10Wid061brVbRZ2wFmvYojIefPcGPo9mx9F+WTjmn38be0Yr+U6pQu00+XD1teXLnGWt/uMKmX669qZecaf0+qsiQ4dXw9XXk0sVARn66m9Onnpg7LL1qtXPxyadVKFPBF7+cTvTtvJEdm5KvawdHa76cXIdmrQvj7mnHg7sR/PbDGZYtvGDGqFOX3c/1qwwbUY1vJtXnp/mn+GJk9vlsTo0ln+e0KHIXoSRYL6tWNzdLFpznwqkANFYqRk2sxR9bOtCo/BJiohP126347SKzxh/R//ziuuygYa0laDTJPcAlSnmxYVs3NqzLPn8wHRysuXQxkOVLLrL0z/Yp1ztac/zIIzauvc6cn5obXb+9ywXsnK8SGVIXbbw7VrbBOHn+w7J9Cu81evWbf/tENU52yT97pp/HpOn4dYUxi3Xsm6pJdf2ZWwqf/arj0/Yq6pdVseWEwqAfdaz9Sk3RXCpi4+HKfQXH0JpYx3ujU8fxzHMvoX7r8HrUO93j9xhZlrYflWBq37+5eyWUYpW8GP1rHaIi4ln7/RUABs6sRoX6OZnc+wD+9yKp0iQXw+bXJPhxNEe23M/8izexDp2KM2VaQ4YN3smpk4/5ZFAV1m3qSqVyvxAcFG3u8ICk6/byhSBWLr7E72vaplg/bkZ9atXPw+D3t/HgXgT1Gudj6rzGBDyJYteWW2aIOHWWcK7TUqGSH30+LG/kFzLzsOTzLF5NxmC95L3W6/lr2RVuXA3h6sVgPvtwF7nzuVCmoq/BdjHRCQQFROuXyGfxZoo4dSHBMQQGROmXZu8U5vatUA7//cDcoent3XWHqeMOsW3Tv6muX7PiCjOnHOHgvruZqt/KNpD4mHwkxORFp3UmProA8TG5uJiB6jydwdtVpV/U6uSETKdT+Hm7jkZjtJQbqKXtBC07Tmf+lpllexVql4IPmqkplEPF0LZqSuaF5fuT6nR2UPH7cA32UcWxSvDEJi4nLiGNSbQNQKuJSLf+UjV8OLz5Hse2P8D/XiQH193l5O5HFK/inbxNdV92LvuXc3/7438vks2/XufWhaeUeGGb7GDQkKosWXSe5csucv1aCMMG7yAmJoFevcuaOzS9/TvvMn3cYYNWqxdVrp6TNcuucPTvhzy8F8Hy3y5y5UIQ5Sv7ZXGkr2YJ5zo1jo7W/LK4NUM/2UFYWKy5w0mXpZ7n9CiKymSLpZIEKx3OrjYAhD01fKO261acc48+ZveZXnw+sRZ29tm3MdDaWk2X7iVZviT7dUG8SYlxPljbPUZtFQ6AxjoEazt/6pZOf992E3XUGaGl72wtZ24aJk+/bFfYeFRh3LtqtoxT07uxilG/6ThxPXNJ1rlbCjVLGH6I1Cql4tzttOvTqeNAAZXONt36Lx8NpGKDnOQu4gJAobIelKnlx/EdD5O3ORZArdZ58crpAECFejnIU8SFk7sfZeYlvRHW1mrKV/Bj/wsJt6LAgX13qVo1l/kCM9KpY49p2qoQfjmdAKhZLw8Fi7hzcM9d8wb2Aks+1zPmNmHX9lsc3HfP3KGky5LPc7oUlekWC5V9s4JsQKWCcTPrc/LwI25cCdGXb1x9nYf3Iwh4HEmJMt6MmVybgkXd+ajrFjNGm7aWbYri6mbHimWXzB1KloqJKIdKnYBbzr8AFaAQHVaZ1tXOprmPtyuM66midH4V8Ynw1z8K783UsXqMmlL5VMQnKPy8XeH34WoqFEp64+fxVnHmpo7V/yhULWb8h0FwBHi6GJZ5uUBweOrbK6pEnnkcxC6yBGol/QRr+fTzOLhYs+xSJ3RaBbVGxa9fn2LPyuTuqLlDjzJiQW3W3utOYoIOnU5h5seHuHDI3+jX86Z4ejlgZaUmKDDKoDwwMIqixTzNFJXxvhq2j+k/NuHMnY9ISNCi0ymMHLCb44eyTzJrqee6Q+cSlCvvR8NaS8wdSoZY6nkWGSMJ1itMmteQoiU96djwT4PyFb9d1P//+uUQAv2jWLWzE/kKunLvdhp/Fc3o3T5l2bPzNv5PIs0dSpaycbiNjeMtIoPro01wR2MTgqP7cdYf0dG+ZuqNtwX9VBT0S06SKhZScT9Iy5I9CtM/UHEvCGLi4YM5hgPhExKhxAv3PVQcrNX/X6uD+ETDstbVVIx/1/gGZAUtYT4bAQWX4KYZ2qdB54I06V6Iib0OcPdKKIXLeTJoVjWCn0Szc1lSN1aHgSUpWdWbMe124X8/knJ1/Bg2rwbBj6M5ve+x0XGKtPUdWIFK1XLQu8N6Ht6LoHqd3EyZ24iAJ5H8sy/7jHezNLlyOzN1ZiM6tFxNXJw2/R3EG2XJXXumYnSC1bdvX+bOnYuzs+Go36ioKAYPHszvv/9usuDMacKcBjR6pyCdG/+J/6NXJyZnTyTd7ZGvkFu2S7Dy5HWhfsN89Oq63tyhZDkH95PEhJclProQANoEDzRWkfyy/Qzta2a8nrIFVJz+fzdh9P97ihcMUuPrbridzQvvpvVfJydPF+4ozFyrsHREctmLA+i9XCDkpaFUwRHg9dJNoApawnw3obWKwONJtwy1XgEM+LYKy2dcYN+ftwG4fSkU37xO9BxVjp3LbmJjp6HfpMp81Wkvx7YnjdG7fTEpEev6aZlsk2CFBEeTmKjD28fRoNzHx5EA/6g09spe7OysGD2hNh902cje7XcAuHopmFJlffh4eOVsk2BZ4rkuV8EPH19HDhzroy+zslJTs3Ye+g2oiK/LTHS67DW9uCWe54xSUt6M/Z9j9FfoJUuWEBMTk6I8JiaGpUuXmiQoc5swpwHN2xSmW/O/eHA3A4OIy/kAEPgk+70herxXhqDAaHZtzz53J2UVlSqRpK7BZIqixtjP2GsPFHz+n+wUypmUSD15qpDPR2Ww5PBIPtaL5T5uKjQawzJPl+RtyxdScfSaYVBHriiUL5i8TUKikpRcWYfi8aQrap19huO3dbBCeelF67Q6/cB9K2s11jaaVLZRDAb3m1tCgo5zZ/2p3yC/vkylgnoN8nHiRPbpXnsVK2s1NjaaFH/otTqdnOvX9Pf+e9Ss+Bt1qy7SL2dOPWHNqsvUrboo2yVXYJnnWWRchluwIiIiUBQFRVF49uwZdnbJX8G1Wi3btm3Dx8fnjQSZlSbNa0jbrsX4sNMmop7F4+2bNOg3IjyOuFgt+Qq60rZrcfbvuEPo01hKlPFi7Ix6HPv7IdcuBZs5ekMqFfR8rwyr/riEVpv9PlwcHa0pUCi5GShffjdKl/UhNDSGRw+e4eZuR+48LvjlSBoMXLioB4D+zsj0xMfkxd71HDqtY9I0DTYh2LtcokmF5D9ks9bpCAyDaX2Tvmss2aMjt5eKwjkhLgH+OqRw7Br8NixpvZOdir5NVUz9U0Gn6KhUWMWzmKSpFpzsSLPr8VV6NVLx3gyF33fpqF9GxdaTCpfvwYReyfNgDf1ZR4KtP+7+HVFUOrSapFZVtdYeFalP//Dcka33eXd0eQLuR3H3SihFynvSZVhpti1Ounsz+lkCZw8+4eNvqxIXk4j//UjK181Bs3cL88PI40a/njfp+3knWLCwFWdPP+HUqSd8MqgyDg42/LE0+9zA4eBoTYFCbvqf8+R3oVRZb8JCY3n04BlHDj7g66n1iI1J5OH9CGrUyUOnniUZP+qg+YJOhSWc6xdFRsZz9YrhZ3B0dAJPQ2JTlGcnlnaeM0y6CDOeYLm5uaFSqVCpVBQtWjTFepVKxfjx400anDm891E5ANbs6WJQ/umHO/lr2RXi47XUbpiXDwZXwN7RmicPn7F9/U3mTc1ef4gA6jfKT568rvyRTe8eLF/Jj427uut/njSjIQArl11kcL/tNG9VmO8XttCv//WPNgBMn3SY6ZMOp1t/1NPqOLidwdHjCGp1LDqtA7GRxRjSNnkMXVA4PH6anHwmJMK0NToCwsDOBorlgt+Hq6lePPnDYmhbFR7OSXcTPgxWcHaAknnho3cyd1NuxUIqZn6oZs5GHbM3KOT3ge8/SZoDCyAgDPadB6yeEZJ7scG+7o+7YRub95X1zx16jA/GV2T4/Jq4+9gR/DiaTQuvs2RS8mD/CT33039yZb5aWh8XD1v870Xy69jTbPw5+8ybBrDur2t4eTnwxdg6+Po6cvFCIB3briYoMPvMF1Suki9rd3fV/zx+RgMAVi+9xPB+OxnQawtfTKzD94tb4OZhx6P7z5j2zWGW/nLeXCGnyhLO9dvgbT3PMgYLVIqSsWdeHzx4EEVRaNiwIWvXrsXDw0O/zsbGhnz58pEzZ843Fqgx8trONncImfJMlb3m0soIDZb3JgraudjcIWRK/cafmTsEo521CjJ3CEZz0lmbO4RMiVQnmDsEo2ks8I+wVpX9egMyIiJmdJYeL2B4D5PV5Tt7hcnqykoZbsGqV68eAHfu3CFv3rxpPmpECCGEEP9t0oKVibsI7927x717aU/gVrdu3dcKSAghhBAWThIs4xOs+vXrpyh7sTVLq5X5R4QQQgjx32b0qNzQ0FCDJTAwkB07dlClShV27dr1JmIUQgghhAVRdCqTLZbK6ATL1dXVYPHy8qJJkyZMmzaNUaNGvYkYhRBCCGFBzPmw50ePHvHuu+/i6emJvb09ZcqU4dSpUy/EpjB27Fhy5MiBvb09jRs35t9//zWo4+nTp/Ts2RMXFxfc3Nz44IMPiIw07mkoJnvYs6+vL9evXzdVdUIIIYQQRgkNDaVWrVpYW1uzfft2rly5wqxZs3B3T55zcfr06cybN48FCxZw/PhxHB0dadasGbGxsfptevbsyeXLl9m9ezdbtmzh77//pn///kbFYvQYrAsXDOdUUhSFJ0+e8O2331K+fHljqxNCCCHE28ZMs1lMmzaNPHnysGjRIn1ZgQIF9P9XFIU5c+bw1Vdf0bZtWwCWLl2Kr68vGzZsoFu3bly9epUdO3Zw8uRJKleuDMD8+fNp0aIFM2fOzPCUVEa3YJUvX54KFSpQvnx5/f9btGhBfHw8v/76q7HVCSGEEOItY64uwk2bNlG5cmU6d+6Mj48PFSpUYOHChfr1d+7cwd/fn8aNG+vLXF1dqVatGkePHgXg6NGjuLm56ZMrgMaNG6NWqzl+POOTihvdgnXnzh2Dn9VqNd7e3gaPzhFCCCGEMIW4uDji4uIMymxtbbG1TfnA+9u3b/PTTz/x6aef8sUXX3Dy5EmGDBmCjY0NvXv3xt/fH0ga1vQiX19f/Tp/f/8Uj/6zsrLCw8NDv01GGJ1g5cuXz9hdhBBCCPEfYsqJRqdOnZriUXzffPMN48aNS7GtTqejcuXKTJkyBYAKFSpw6dIlFixYQO/evU0WU0ZkapD73r17adWqFYUKFaJQoUK0atWKPXv2mDo2IYQQQlggU07TMGbMGMLDww2WMWPGpHrcHDlyULJkSYOyEiVKcP/+fQD8/PwACAgIMNgmICBAv87Pz4/AwECD9YmJiTx9+lS/TUYYnWD9+OOPNG/eHGdnZ4YOHcrQoUNxcXGhRYsW/PDDD8ZWJ4QQQgiRJltbW1xcXAyW1LoHAWrVqpViRoMbN27oe98KFCiAn58fe/fu1a+PiIjg+PHj1KhRA4AaNWoQFhbG6dOn9dvs27cPnU5HtWrVMhy30V2EU6ZMYfbs2QwaNEhfNmTIEGrVqsWUKVMYOHCgsVUKIYQQ4m1ipkflDB8+nJo1azJlyhS6dOnCiRMn+OWXX/jll1+ApCfPDBs2jEmTJlGkSBEKFCjA119/Tc6cOWnXrh2Q1OLVvHlz+vXrx4IFC0hISGDQoEF069Ytw3cQQiZasMLCwmjevHmK8qZNmxIeHm5sdUIIIYR4y5jrLsIqVaqwfv16Vq5cSenSpZk4cSJz5syhZ8+e+m1GjRrF4MGD6d+/P1WqVCEyMpIdO3YY3Ky3fPlyihcvTqNGjWjRogW1a9fWJ2kZpVIUxajZKnr06EGFChUYOXKkQfnMmTM5deoUq1atMiqAN8HF/ltzh/CfUSMh4/3R2cVpq8D0N8qGAtctN3cIRnPr2N3cIRitgNbF3CFkyh1NhLlDMJqNYrK5rrNMvEpn7hAyJSJmdJYe736/D0xWV96Fv5msrqxkdBdhyZIlmTx5MgcOHND3Vx47dozDhw/z2WefMW/ePP22Q4YMMV2kQgghhLAIpryL0FIZnWD99ttvuLu7c+XKFa5cuaIvd3Nz47ffkrNMlUolCZYQQgjxH2Rc39jb6bUnGhVCCCGEEIaM7gCfMGEC0dHRKcpjYmKYMGGCSYISQgghhOUy1yD37MToBGv8+PFERkamKI+Ojk4x06oQQggh/oN0KtMtFsroBEtRFFSqlC/4/PnzeHh4mCQoIYQQQghLluExWO7u7qhUKlQqFUWLFjVIsrRaLZGRkXz88cdvJEghhBBCWA5L7tozlQwnWHPmzEFRFPr27cv48eNxdXXVr7OxsSF//vz6aRuEEEII8d8lCZYRCdbzp1AXKFCAmjVrYm1t/caCEkIIIYSwZEZP01CgQAGePHmS5vq8efO+VkBCCCGEsGzSgpWJBCt//vypDnJ/TqvVvlZAQgghhBCWzugE6+zZswY/JyQkcPbsWb777jsmT55sssCEEEIIYZmkBSsTCVa5cuVSlFWuXJmcOXMyY8YMOnToYJLAspt+H1VkyPBq+Po6culiICM/3c3pU2l3lZpbzVp5GDq8GuUr+pIjhzPdu6xl6+Z/s6w+Dz97+s+oQpFKnuQs7MLG+VdZ8NmJTB8/o8rW86P/jCrkK+VG8IMoVky5wO6lN/Xru35ehm/b56RIMU9iYhI4eewxE748yM1/n2b6mGq1ilFf16Jz95L4+Dri/ySSVcsuMWvq0UzUpsPe9Sy2TjdRq2PQaR2IiypCTHj5NPfYdUHLqsNarj3SEZ8Ihf1UDGpuRe3imky/pozYcU7LvO2JPHqqkM9bxWetrKhXMumYCVqFudsS8fJbj8YqEkVnTVxcTp6FVUandXit42bn9+LHX1dhwNdVDMruXA+lXZmV5MznzPZ/e6W634juO9m99lZWhGiU7HyuX2ba92HWsqTznGGSYBk/D1ZaihUrxsmTJ01VXbbSoVNxpkxryLeTD1GnxiIuXghk3aaueHm/3h+KN8nR0ZpLFwP4bNhus9RnbashLCiWlVMucPt85pOXF/nmc2JnYp+01+d3YuKmRlw4+IRPKm1i/bwrDP+lJpWa5tRvU7auH7/9fJZmdZfRqeWfWFurWbO1Mw4Omb9pY8iIarzfrzyjh+2hZvnfmPDlQQZ/Wo1+n1Q0ui57lwvYOV8l6mkNwh53JDqsCvYuF7FzvpLmPqdu6ahZVM3P/W346zMbqhVR88mvCVx5qMv0azpxU0ujCbFprj97R8eIZQl0rKZh3QgbGpVWM/j3BG48STpmbDxceagQGVGeYP82hAY3xMoqHHevPZmOCSzjvXjzcggN8yzSL33qrwfA/0GkQXnDPIv4cfwJop7Fc2jHPTNHnZIlnOsXmfJ9mJUs7TyLjDO6BSsiIsLgZ0VRePLkCePGjaNIkSImCyw7GTSkKksWnWf5sosADBu8g2bvFKJX77LMnnnMzNGlbveu2+zeddts9QXci2TBp0ktVk3fT/u6aN63CB2Hl8KvgDMBdyPZ8P0Vtiy4nqkYW31UDP87kfwy8hQAD66FU6qWLx2GluL0rscAfNlyN6etAvX7DOq3jesPB1Ouoi9HDz3M1HGrVs/F9i032b0j6fw8uBdBhy4lqFglh9F1WdkGEh+Tj4SYpJtF4qOdiXe4jZVNUJr7fNHeMDkc3lLN3os69l/WUTJ30nconU7h131a/jyqJfiZQn5vFQOaWNGsfOZauZb+nUjt4mo+aJj0ETK0hZojN3Ss+EfLuC5qnO1V/D7ABrc9BQDQAhGh1fHy24JaE4lO65Sp41rCezExUSEkICZFuU6Xsrxh2wLs+usWMVGJWRVehlnCuX6RKd+HWcnSznNGKZn/fvfWMLoFy83NDXd3d/3i4eFByZIlOXr0KD/99NObiNGsrK3VlK/gx/59d/VligIH9t2latVc5gvsLdCge0HeG1eBxV+f4cPS61n01Wl6j69A416FMlVfierenN1r2Kx+etcjSlT3TnMfFxdbAEKfpt1ak54Txx5Rt0E+ChV2B6BUGW+q1czN3p3GPxg9Mc4Ha7vHqK3CAdBYh2Bt5098bO4M16HTKUTHKbi98AX4l71aNp7UMq6zFZtH2dC7noZRyxM4cTNzn4Ln7+qoUdTw46N2MTXn7qVdn0qVgKKAorPJ1DEt5b2Yr7Aru+/2Zuu1nkxZ0hi/PKknkyUqeFO8vDfrF13N4gjTZynn+kWmfB9mFUs8zxklzyLMRAvW/v37DX5Wq9V4e3tTuHBhrKyMri7b8/RywMpKTVBglEF5YGAURYt5mimqt8N735Tnl5EnObzhPgABdyPJW9KNlv2LsWeZ8eNR3H3tCQ00bCEIDYzB0dUGGzsN8bGGd7iqVDB5ZiOOHXnItSvBmX4dc2ccw9nZhqMXPkSr1aHRqJn8zd/8tSrtbr20xESUQ6VOwC3nX4AKUIgOq0x8VGHgeIbq+H2/luh4aP7/1qn4RIVf9iTy2wAbKuRPSoryeKk5fVvhz6OJVC1sfMIT/Ay8nA0/+DydVQRHKGnskYiL+yliowuiKJlLsCzhvXjxRABff7iPuzfC8PZz4KOvqrBoX3s6VlhFdGSCwbbt3y/BratPOX/M30zRps0SzvXLTPk+zCqWeJ5FxhmdEdWrV+9NxCH+Y2wdrMhZ2IXhC2sx7Oea+nKNlZqo8Hj9z7+cb4tPvqQWgOezg2wI66lff+lQAF+1yty4nulzm1C8lBctGy7P1P7PtetUnE7dS/JR781cuxJM6XI+TJ7RCP8nkaz+47JRddk43MbG8RaRwfXRJrijsQnB0f04SgYHhm85reXHXYl839caz/8nQPeCFGLi4cOf4g22TdBCiVzJSVKlz5Nb8bQKxCcalrWupGFcl8yMVdPh7nUAUAh/+nY/7eHwzvv6//97MYSLJwLYfrMXzToVZv3i5JYqWzsN73QrwsIpp8wR5lvJlO9D8fosueXJVIxOsNasWcPKlSu5ceMGAEWLFqVHjx506tTJ5MFlByHB0SQm6vD2cTQo9/FxJMA/Ko29RHrsnZIuvTkfHeH6CcPxRVptcivIV633YGWd1OrimcuBmfve4ZNKm/Tr42KSW6VCA2Jw97E3qMvdx56o8PgUrVffzm5M0xaFaN14JU8eRb7Waxk3tT5zZxxn/ZprAFy9HEyevK4MG1nd6A92B/eTxISXJT46qZtUm+CBxioSe9fz6e679YyWr1cnMLu3NTWLJY+tiv5/XvVTPxt8XQ33sbFK/hBcNyK5ZenCfYVZmxNYMjC5zMkueVsvZwh+ZthaFfJMwcvl5Q9VHe5e+9FYRRIS2DzTrVdgme/FZ+Hx3Ps3nDyFDU98k46FsHewYvMfmRtv+KZZ4rk25fswq1jiec4oSbCMGIOl0+no2rUrXbt25cqVKxQuXJjChQtz+fJlunbtSrdu3VCUtLoHLFdCgo5zZ/2p3yC/vkylgnoN8nHixCPzBWbhwgJjCX4URY6CTjy+9cxgCbibnPAE3o/SlwfeS/rAeXHbkMfR+m2vHguifEPDAa0VG+fk6jHDBO7b2Y1p2aYI7Zut5v7d8Nd+Lfb21ig6w2tfq9WhVhv/AaNSJZLUNZhMUdTAq99bW89o+XJVAjN7WVO/lOHA9cK+Kmys4EmoQj5vtcGSwz35WC+W+7qCRm1Y5vlCl2C5/GqO3TAcb3Xkho7y+ZI/UhK0yv+TqwieBjZH0dkZeTYMWeJ70d7RijwFXQh+YvjHsl2fEhzYcpfQ4MyP/XuTLPJcm/B9mFUs8TyLjMtwC9bcuXPZs2cPmzZtolWrVgbrNm3axPvvv8/cuXMZNmyYqWM0u+/nnWDBwlacPf2EU6ee8Mmgyjg42PDH0gvmDi1Njo7WFCzkrv85f343ypT1ITQ0locPIl6xp3H1eQc6EvQgivcnV8QrpwMz3j+k36ZgOQ8g6Y+Mq7ctBct5kBiv5f7VpKRm2fhzDJhTjajwBE7tfIS1rZqilbxwcrdh3Rzjx01s+fk6bT4pzgffVmLXopuUa+BH3c75+bpNchfioPnVqds9P706rycyMh4f36RvjhHhccTGZu5Orp3bbjL88xo8fBDBtavBlCnny4AhVVix5KLRdcXH5MXe9Rw6rSPaeHesbEKwd7lEXGQRIGnese+2JBAQrjCtZ1Jr0JbTWsasSGBMeyvK5lMT9P9xUHbW4GyvwtFOxfsNNHy7MWmQecWCKp7FJE214GSnol1V4+8kfK+uFe99H8+i/YnUK6lm21ktlx8ojO+SPA/WsMUJWNsE8zSoCaBDrU5KhnU6WyBzdy9m9/fip9/W5ODWuzy5/wzvHI4MGFsFrVZh++rkOePyFHKhUp2cDGyzxYyRpi+7n+uXmfJ9mJUs7TxnlLRggUrJYLNT2bJlGTZsGH379k11/W+//cbcuXO5cMH8F4WL/bcmr7P/x8kTwV28EMioz3Zz6mT2nQiudp28bNvVI0X58mUXGdB/q8nq27XkJrM+OMRnv9XGN78Toxrt0K9Lbc4q/7uR9C78l/7nBt0K0Omz0uQt6UZcVCJ3LoWyfu4Vjmy8n2Jf33xOLL3ViWZWi9OMs2w9Pz6aWYW8Jd0IfhjFismGE42mNY/WoH7bWLXsUpr1voqTkw2jv6lNy7ZF8PJ2wP9JJOv+vMrMyUdISDDyLj1VPA5uZ7BxuItaHZs00Wh0QWLCKhC4bhUAY1bE8+ipwtJBSXdAvvd9HCdvpXwbt6uiZmqPpCRMURSW/a1l1REtD0MUnO2hZG41/RtbUaVQyobsEzeTkra9Y9NuddpxTsvcbckTjY5onTzR6KOnOhpPjE91v5CA5sTHZf7W+Tf9Xiygdcn0vtP+aELF2jlx87QjNCiGs0eeMH/scR7eTv5SM3hiNVp2L8o7RZZhykb/Oxrjvzil502faxvFZFMxmvZ9+ArxKtPPP5AVf18iYkabtL70XOk0zGR1lfxrjsnqykoZTrDs7e25fv16mg9zvnfvHsWLFycmJuX8L1ntTSRYInU1EvzMHYLRXpwHy5IErnu9wfjm4Naxu7lDMNrrJFjm9CYSrDfNlAlWVnkTCVZWkAQr62X46ra3tycsLCzN9REREdjZvd4YCyGEEEJYPpkHy4gEq0aNGq+cSPSHH36gRo23+xZsIYQQQqRPEiwjBrl/+eWX1K9fn5CQEEaMGEHx4sVRFIWrV68ya9YsNm7cmGISUiGEEEKI/6IMJ1g1a9Zk9erV9O/fn7Vr1xqsc3d3Z+XKldSqVcvkAQohhBDCssizCI2caLR9+/Y0a9aMnTt38u+/SbcdFy1alKZNm+LgIE/+FkIIIYRM0wCZmMndwcGB9u3bv4lYhBBCCCHeCm/f05mFEEIIYVbSgiUJlhBCCCFMTBIsI6ZpEEIIIYQQGSMtWEIIIYQwKWnBymCCFRGR8UcwuLhY5mMmhBBCCGEakmBlMMFyc3NDpcrYydJqta8VkBBCCCGEpctQgvXiDO13795l9OjR9OnTR/9onKNHj7JkyRKmTp36ZqIUQgghhMWQFqwMJlj16tXT/3/ChAl89913dO/eXV/Wpk0bypQpwy+//ELv3r1NH6UQQgghLIdOEiyj7yI8evQolStXTlFeuXJlTpw4YZKghBBCCCEsmdF3EebJk4eFCxcyffp0g/Jff/2VPHnymCwwYRmOWvubO4T/DLeO3dPfKJt5GPK7uUMwWm7PvuYOIVNcdDbmDsFoEep4c4dgNBtFZjfKCOkizESCNXv2bDp27Mj27dupVq0aACdOnODff/9N8RBoIYQQQvz3SIKViS7CFi1acOPGDVq3bs3Tp095+vQprVu35saNG7Ro0eJNxCiEEEIIYVEyNdFonjx5mDJliqljEUIIIcRbQFHMHYH5Zaoz+Z9//uHdd9+lZs2aPHr0CIBly5Zx6NAhkwYnhBBCCMujKCqTLZbK6ARr7dq1NGvWDHt7e86cOUNcXBwA4eHh0qolhBBCCEEmEqxJkyaxYMECFi5ciLW1tb68Vq1anDlzxqTBCSGEEMLySAtWJsZgXb9+nbp166Yod3V1JSwszBQxCSGEEMKCWXJiZCpGt2D5+flx8+bNFOWHDh2iYMGCJglKCCGEEMKSGZ1g9evXj6FDh3L8+HFUKhWPHz9m+fLljBgxggEDBryJGIUQQghhQaSLMBNdhKNHj0an09GoUSOio6OpW7cutra2jBgxgsGDB7+JGIUQQghhQRR5FqHxCZZKpeLLL79k5MiR3Lx5k8jISEqWLImTk9ObiE8IIYQQwuIY3UXYt29fnj17ho2NDSVLlqRq1ao4OTkRFRVF376W+QwvIYQQQpiOdBFmIsFasmQJMTExKcpjYmJYunSpSYLKjvp9VJGL1wYQGDqCfX+/R6XKOcwdUoZYYtwSc9YxZdwqVQIubsfxzvknfrmX4um7hcuX095+3FioUkGVYunSMdMhZMie3dCpPdSqBt06w+F/ktclJoCz20m8/Nbjm3sZPjlX4er5N2pN9GsdM7tfHwNHVmHL4R5cCx7EuQcf8+uaNhQs6q5f7+Zux8TZDTh4sQ83w4Zw/N8PmfBdA5xdstcDpmvWysPqvzpx/fZAImJG07J1EXOHlEKN2rlZvrYDl25/QnDsKN5pXdhgfcu2RVizpTM3Hg0mOHYUpcv6mCnS1yMJlhEJVkREBOHh4SiKwrNnz4iIiNAvoaGhbNu2DR8fy7wQ0tOhU3GmTGvIt5MPUafGIi5eCGTdpq54eTuYO7RXssS4JeasY+q4XT0OYWP3mPCQugT5tyMuNhcDP4bAwNS3HzEStu9W9MuWHQqurgqNm2T+NZ0+BW1e8UjU8+fgqzHQth38sRLq1YcRn8LzG6NjY8Ha+imREeUJ9m9DaHBDrKzCcffak+mYLOH6qFE3D0sWnKNNnZV0b/EX1tZqVmzpiL1D0igS3xyO+OZwYuLov2lUcQnD++2kftP8zPy5qZkjN+ToaM2liwF8Nmy3uUNJk4ODNZcuBjIqjRgdHK05fuQRE746mMWRCVPLcILl5uaGh4cHKpWKokWL4u7url+8vLzo27cvAwcOfJOxms2gIVVZsug8y5dd5Pq1EIYN3kFMTAK9epc1d2ivZIlxS8xZx6RxqxKxc7jHs7DKxMf5oU10ITK8AnnywNo1qe/i5AxeXsnL1SsQEQGt2yRvo9PBot+gbUuoXR16dIG9r/G3c9VKqFETevWGAgVhwEAoXgLWrEqO6WlQM2KjC6BNdCUh3oeI0OrY2Iag1kRm6piWcH2823oda5Zd4cbVEK5eDGb4hzvJnc+FshV9Abh+JYT+3TazZ+tt7t0O58iBB0wbe4jGLQui0WSfFobdu24zcfw/bNl0w9yhpGnvrjtMHXeIbZv+TXX9mhVXmDnlCAf33c3awExMWrCMGOS+f/9+FEWhYcOGrF27Fg8PD/06Gxsb8uXLR86cOd9IkOZkba2mfAU/Zs04qi9TFDiw7y5Vq+YyY2SvZolxS8xZx9Rxq1BQqRQURWNQbmsL585mrI6NG6BqNcjxwsfI4t9h+zYY/SXkyQtnz8DYr8DNHSpVNjpMLl6AHu8allWvAQf3p72PSpWAooCiM747zFKvDxdXWwDCnsa+cpvIiHi0Wnmqr0jJkhMjU8lwglWvXj0A7ty5Q968eVGp/hsnz9PLASsrNUGBUQblgYFRFC3maaao0meJcUvMWcfUcSuKNfFx3ji5nicsxA2d1g57hztcvAC586S/f1AgHD0ME194nGl8fFLr1Q8LoGy5pLLcueH8WVi/NnMJVkgweHoYlnl4QkhIWnsk4uJ+itjogiiK8QmWJV4fKhWMm1mfE4cfcf1K6ifG3dOOoWOqs/y3i1kcnRCWw+hpGvbt24eTkxOdO3c2KF+zZg3R0dH07t3bZMEJISxHWEhdXD0O4ZtrNYqiIiHek6bN4drV9Pfdsjmpe65+g+SyBw8gNlbFoAGGLSQJCVCsePLPdWsm/1+nS0rMXix7pwWM+Sozr0iHu9cBQCH8aY3MVGCRJs9rRLGSnnRouDrV9U7ONizd0J5/r4Xw3cSjqW4jhLRgZSLBmjp1Kj///HOKch8fH/r37//WJVghwdEkJurw9nE0KPfxcSTAPyqNvczPEuOWmLPOm4hbm+jC08AWqFQJqFQJ6HQOJCb+Tq50esIUBTZvhBYt4YXnxxPz/xv3Zs+Dl++fsX6hMWn5quT/X7oE38+FBQuTyxxfmKLP0wtCnhrW9TQEPFM0Julw99qPxiqSkMDmmWq9Asu7PibNaUjjdwrSsfFqnjxKOebM0cmaPzZ3IDIyng87byIxUWeGKIUlkAQrE9M03L9/nwIFCqQoz5cvH/fv3zdJUNlJQoKOc2f9qd8gv75MpYJ6DfJx4sQj8wWWDkuMW2LOOm8ybkWxRqdzQKWK49gRqFv/1dufOQ0PHqho086wvEBBsLFRCPBPGn/14uLnl7zdi+U+PqDRGJa9MFyUMmXh5AnD4xw/llSe7HlyFcHTwOYoOjvjT8L/WdL1MWlOQ5q3KUzX5mt4cDcixXonZxtWbO1IQryW9ztsJC5Oa4YohbAcRrdg+fj4cOHCBfLnz29Qfv78eTxTfg18K3w/7wQLFrbi7OknnDr1hE8GVcbBwYY/ll4wd2ivZIlxS8xZx9Rx29g9QoVCYoIrGusIXNxOkb8AtGnz/HhJY63GTzLcb+MGKF1GobDhdEA4OsK778F3s5K6/spXgMjIpKkWHB2hVRuM1q07fNQP/lgKtevArp1Jdy9+8XXS+sQEcPfah7VNCE+DmgA61OqkpjSdzhbQpFl3Wizh+pg8ryHtuhbng06biHwWj7dv0hQSz8LjiY1N1CdX9g5WDHl/O84uNvo5sEKCYtDpssdAd0dHawoWSp6/K39+N8qU9SE0NJaHD1Imjebg6GhNgRdizJffjdJlfQgNjeHRg2e4uduRO48LfjmSml4LF036hhAYEEVgQPZr9UyLtGBlIsHq3r07Q4YMwdnZmbp16wJw8OBBhg4dSrdu3UweYHaw7q9reHk58MXYOvj6OnLxQiAd264mKPD1Jh980ywxbok565g6brU6HmfX02isotDpbImNzsf8H0Kw+n+3X3Aw+Psb7hP5DPbthc9Gpl7nx58k3TG4eBE8mgjOzlCsBLyfyYdGlCsPk6bATz/Aj98ntXDN/A59chcYBHYODwDwzrHRYN+QgObExxk/QaglXB+9PyoPwF97uhiUD/9wB2uWXaFMBR8qVkt67YevfmCwTfWiv/LwXvZIXipUzMG2XT30P0+d3giA5csuMqD/VnOFZaB8JT827uqu/3nSjIYArFx2kcH9ttO8VWG+X5g8mduvfyR9k5g+6TDTJx3O2mBfgzyLEFSKohj11SM+Pp5evXqxZs0arKyS8jOdTsd7773HggULsLEx/8y+LvbfmjsEIQTwMOR3c4dgtNyelvnIL5dMTCNhbhHqeHOHYDQbxeiRNdlCcOyoLD3e3qqm+zvc6MRok9WVlYxuwbKxsWH16tVMnDiR8+fPY29vT5kyZciXL9+biE8IIYQQFka6CDORYD1XtGhRihYtaspYhBBCCPEWMK5v7O2UoQTr008/ZeLEiTg6OvLpp5++ctvvvvvOJIEJIYQQQliqDCVYZ8+eJSEhQf//tPxXZncXQgghRNp00kWYsQRr//79qf5fCCGEEOJlMgYrExONCiGEEEKIV8tQC1aHDh0yXOG6desyHYwQQgghLF92acH69ttvGTNmDEOHDmXOnDkAxMbG8tlnn7Fq1Sri4uJo1qwZP/74I76+vvr97t+/z4ABA9i/fz9OTk707t2bqVOn6qenyogMtWC5urrqFxcXF/bu3cupU6f060+fPs3evXtxdXXN8IGFEEII8XZSFJXJlsw6efIkP//8M2XLGjwLi+HDh7N582bWrFnDwYMHefz4sUFDklarpWXLlsTHx3PkyBGWLFnC4sWLGTt2rFHHz1AqtmjRIv3/P//8c7p06cKCBQvQaDT6YD755BNcXFyMOrgQQgghhKlFRkbSs2dPFi5cyKRJyc/nCg8P57fffmPFihU0bJg0i/6iRYsoUaIEx44do3r16uzatYsrV66wZ88efH19KV++PBMnTuTzzz9n3LhxGZ5Q3egxWL///jsjRozQJ1cAGo2GTz/9lN9/t7xZm4UQQghhWqZswYqLiyMiIsJgiYuLe+XxBw4cSMuWLWncuLFB+enTp0lISDAoL168OHnz5uXo0aMAHD16lDJlyhh0GTZr1oyIiAguX76c4XNgdIKVmJjItWvXUpRfu3YNnU5nbHVCCCGEeMsoOpXJlqlTpxoMVXJ1dWXq1KlpHnvVqlWcOXMm1W38/f2xsbHBzc3NoNzX1xf//z8s1d/f3yC5er7++bqMMnom9/fff58PPviAW7duUbVqVQCOHz/Ot99+y/vvv29sdUIIIYQQaRozZkyKSc5tbW1T3fbBgwcMHTqU3bt3Y2dnlxXhpcnoBGvmzJn4+fkxa9Ysnjx5AkCOHDkYOXIkn332mckDFEIIIYRlMeVdhLa2tmkmVC87ffo0gYGBVKxYUV+m1Wr5+++/+f7779m5cyfx8fGEhYUZtGIFBATg5+cHgJ+fHydOnDCoNyAgQL8uo4zuIlSr1YwaNYpHjx4RFhZGWFgYjx49YtSoUQbjsoQQQgjx32SuuwgbNWrExYsXOXfunH6pXLkyPXv21P/f2tqavXv36ve5fv069+/fp0aNGgDUqFGDixcvEhgYqN9m9+7duLi4ULJkyQzHkqmHPScmJnLgwAFu3bpFjx49AHj8+DEuLi44OTllpkqTahCfy9whZMp+m0fmDsFotRIyns1nF5c1oeYOIVNy6cz/3jJWbs++5g7BaLeHnDF3CJlScF7F9DfKZuwVy/tSHqPSmjsE8QrOzs6ULl3aoMzR0RFPT099+QcffMCnn36Kh4cHLi4uDB48mBo1alC9enUAmjZtSsmSJenVqxfTp0/H39+fr776ioEDB2a4JQ0ykWDdu3eP5s2bc//+feLi4mjSpAnOzs5MmzaNuLg4FixYYGyVQgghhHiLZJeJRlMze/Zs1Go1HTt2NJho9DmNRsOWLVsYMGAANWrUwNHRkd69ezNhwgSjjmN0gjV06FAqV67M+fPn8fT01Je3b9+efv36GVudEEIIId4y2elhzwcOHDD42c7Ojh9++IEffvghzX3y5cvHtm3bXuu4RidY//zzD0eOHEkx0Vb+/Pl59MjyuriEEEIIIUzN6ARLp9Oh1absg3748CHOzs4mCUoIIYQQlis7dxFmFaPvImzatKn+gYkAKpWKyMhIvvnmG1q0aGHK2IQQQghhgbLDswjNLVPzYDVv3pySJUsSGxtLjx49+Pfff/Hy8mLlypVvIkYhhBBCCItidIKVJ08ezp8/z+rVqzl//jyRkZF88MEH9OzZE3t7+zcRoxBCCCEsiCJPzjMuwUpISKB48eJs2bKFnj170rNnzzcVlxBCCCEslCV37ZmKUWOwrK2tiY2NfVOxCCGEEEK8FYwe5D5w4ECmTZtGYmLim4hHCCGEEBZOp6hMtlgqo8dgnTx5kr1797Jr1y7KlCmDo6Ojwfp169aZLDghhBBCWB7pIsxEguXm5kbHjh3fRCxCCCGEEG8FoxOsRYsWvYk4skyJWt70nlqRXMVdsXXQEHQvip2//MumuVff6HFrdspLz/Hl8cnvxON/I1g65gyntz8GQGOloufE8kxp0Yz8BdyIiIjjwL57fPP1AfyfRL7Wcft9VJEhw6vh6+vIpYuBjPx0N6dPPTE+/lp5GDq8GuUr+pIjhzPdu6xl6+Z/09ze3c+efjOqUKSSJzkLu7Bp/lV+/uzE67yUDClTz4/+M6qQr5QbQQ+iWDnlAnuW3tSv7/J5GSq2z0WhYh7ExiRy+thjpn55iNs3MvYA6IEjq9C8XeF0969YLQcjx9ekQtUcaLU6rpwP4t1W64iLNc+DYtf9240c+VNOBLz2p8vMHHKEXAWdGTytOmVr+WJjq+HYzofMGnaE0MAYM0T7aqa6pgFy5HRiwqT6NGlaCHsHK27fCsVqXxiJj26nu69VvmK4fjQObcADwuaOytTxM8qmTHUcmnZF4+6NNtifqO3LSbh+NmmlWoNDs24c7VUj235+vAnVa+dm4PAqlK3gh19OJ/p0Xs/2zUnvdSsrNaPH1aZx84LkK+BKRHg8f++/x6SvDhLwJMrMkaeUnc9zZkkLlhFjsHQ6HdOmTaNWrVpUqVKF0aNHExOT/T580xMblcjWH6/zRf2dDCq1iT+nXKTnxPI07Vck03WWrufLL7fap7m+eA1vRiyvw57fbzK80haOb3zAmHX1yVvKDQBbBysKVfRk+rdHqFNjMe92W0+Roh6sWvN6LYUdOhVnyrSGfDv5EHVqLOLihUDWbeqKl7eD0XU5Olpz6WIAnw3bnaHtrW01hAfFsmrKBe6cf2r08VLjk8+J7Yl90lzvm9+JCZsacf7gEwZW2sSGeVcY9ktNKjbNqd+mTF0/liw4T7s6q+jZYi1W1mr+2NIBe4eMfdeoVjd3uvtXrJaDpZvb88+e+7SptZLWtVay5KfzZr1tuW+NDbTM/Yd+GdJsKwB7/7qDnYMVc7a1QFEUBjfdykf1NmFlo2bmhqaostlnpCmvaTc3W3bt60VCgo6O7f6kaoVf+XL0PnQx6f8BVtk54Nx1IAm3LmbmZRiwLlgS98+/T3O9Vb6iOHcfStzJfYTN+5z4KydxeW8kGt88SbHY2GCVq0C2/vx4ExwcrLl8MYjRw/akWGfvYEXZCr58N/UojasvpW+3DRQu4s7SvzqYIdJXy+7nObNkolFQKYqiZGTDiRMnMm7cOBo3boy9vT07d+6ke/fu/P777286RqO11SwzavvRf9UjNiqROb0PA6BSQYdRpWnWrwhufnY8vhHBn5MvcmTt/VT3L13PlyG/16R/ofWprh+5sg62jlZMarNfXzb9cHPunA/lp0+O68v22yQ/y7FiJT8OHOpDyaI/8vBBhFGv57l9f7/HmdNPGDF8t/51Xb05kJ9/Os3smccyVSdARMxofQtWrQS/dLeftrc5t889TbUFq1nfInQYXgq/As4E3I1k4/dX2Lrgeqr1+ORzYsmtTrxjtTjV9X2nVqLKO7kZUH6jvmz08no4utnwdcvkxPCyJrm1ycPLnnOPPqZToz85ccj4Z2mmtv+Gv7vxz957zBp/1Oj6XiWXzslkdQ2bVZ1aLfLSucSfVG2ci++2NKep91KinyUA4Ohiza6g3gx7Zxsn9z3O9HEuW4WYKmTAtNf0uIn1qF4jN80bLzcovz3kTLr7OvcYijbYH3Q6bEpVMWzBUqmwr9cWu2qNUTu7oQ16TPS+tcRfPJ5qXdYFS+LU+RNCpw1K41jDUNnYErF4mr7MdeAkEh/fI2r9Qn1ZwXkV9f/Pzp8fL7JXNCapJyB2pEELVmrKV/Jj5+FeVCyygEcPnmX6WDEq07ZCZ8V5hqTP7ay0Iv8vJqurx93+JqsrK2W4BWvp0qX8+OOP7Ny5kw0bNrB582aWL1+OTmfZs4kVKO9O8RreXP47QF/WaXRpGvQqyE+fHGNwmc1smnuV4UtrU6quT6aOUay6N+f3GDb3nt31mGLVvdLcx8XFFp1OITwsc9NiWFurKV/Bj/377urLFAUO7LtL1aq5MlWnqTXoXpBe4yqw5Osz9C+9nsVfnea98RVo3KtQpuorXt2bc3sNz/PpXY8oUd07zX2cXZMeWh72NHPn+eX9Pb3tqVgtByFBMaw70JXT9/vz5+7OVKmZ81XVZCkrazXNehRhy+IbANjYalAUSIhL/sMRH6tFp1MoWyv9BDqrmPqabtGyCGfP+LNkeTtu3RvMP0ffp/f75dLdz7ZyfdQevkTvWZPqevv67bCtVJfI9QsJ/e5TYg5txbnrYKwKlDA6RkhqwYq/adhSlnDjPNZ50251/y98fhjLxfX5OYkzdyh6b+N5fk7uIjQiwbp//77BswYbN26MSqXi8ePMf7s1p9/udeCv6B7MOtGCbT9eZ/dv/++7t1HTaUwZ5n94hLO7nhBwJ5J9S25zcPltmvUvmqljufnZERZo+EEXFhCLu1/qM9/b2moYP6kBf/15hWfP4jN1TE8vB6ys1AQFGnZ3BAZG4evnmMZeWevdb8qzcORJjmy4T8DdSI5suM/6uVd4p3+xTNXn7mufYsxQWGAMjq422Nil/KasUsG4mfU5efgRN64Y39KS2v55C7gCMPyr6qz8/SLvtV7PpXOBrNjRkfyF3Yx/UW9Avbb5cXKzYevSpATr0vFAYqMSGTi1Krb2GuwcrBg8vTpWVmq8cmSfbgpTX9P5C7jxQb8K3Lr5lPZt/uS3hWeYPqsxthXrpbmP2tMPx+Y9eLZqPqT25VJjhUPD9kSu+YmEG+fRPQ0k7vRB4s7+g121JkbHCKB2ckP3LNygTPcsHLWzW6rb/1c+P4xha6vhq0l1Wf/nVSIzeU7ehLftPL9IUUy3WKoMD3JPTEzEzs7OoMza2pqEhASTB5UVxtTbhb2TFUWre/HelIo8ufWMf1bdJUdhZ+wcrRi/s7HB9lY2au6cTe5aWhXeTf9/tUaFta3GoOzg8jsG3X8ZZWWlZskf7VCpYPiQnZl4ZZbB1sGKnIVdGLawFkN/rqkv11ipiQpP/gBccL4tPvmSusaejwdaF5b8BIFLhwIY2yrlGIyMmDSvIUVLetKx4Z8m21+tTgpy+a8XWbP0CgCXzx+kVoM8dO1dimlfH87UsUyp1fvFOLbjAcFPogEIC47ly257GPl9bToPKo1Op7B79S2unQlCp7PgT7d0qNUqzp55woRv/gbgwvkASpby5oOWTYg7czDlDioVzt2HEL17Dbrg1Acga7z8UNnY4frh1y+tsCLx8R39j54Tlr4YCGisDMpiz/5j0P2XUf+Vzw9jWFmpWbi8DSqVilGDMzaGVAhTyHCCpSgKffr0wdbWVl8WGxvLxx9/bDAXlqXMgxV4N+numnuXwnDzsaf72LL8s+ou9k7WAExsvY+QR4atIYkvdKEMq7hV//9i1bx4b2oFvmyY/OaNiUhOPMP8Y3HzMUxO3XztCPU3rN/KSs2S5e3Ik9eV1u+syPS3T4CQ4GgSE3V4+xh+C/LxcSTA3/x30dg7JV168z46wrUTQQbrdNrkP+pjW+9BY53U0OqVy4Hp+95hYKVN+vXxMcm/k9CAGNx9DFsF3XzsiQqPJ/6lu/cmzGlAo3cK0rnxn/g/Mv5Oq7T2D/z/uf33qmGL2M1rT8mZJ+VdfFnNL68TVRrlZExnw6T0xJ5HdC6+GldPW7SJCpHh8Wx50JPHt9O/my6rmPqa9veP5NpLv6fr10JQ9yyY6vYqW3us8xTGKmcBHNv2/X+hCpVajeeUlUT8NgklPqn7KXzRVHQRL93c8cLkzKFzR+r/b52nCA4tehL+8zh9mRKb/NmgiwxD7exqUJXa2RXdszCDsv/S50dGPU+ucud1oWPz1dmq9QrenvOcGkVnuV17ppLhBKt3794pyt59912TBmMuajVY2SZ1IT24EkZ8rBbvvI5c/jswzX38byUPkvTK7YA2UTEoe9H1Y0GUbZSDzfOu6cvKN87B9WPB+p81ViqWLG9HoULutGy+gqeZHBP0XEKCjnNn/anfIL9+OgWVCuo1yMcvC9IfxPumhQXGEvwoCr+CTuxfmfYf8cD7yR8y2sSkxOtJGuf52rEgKjfPbVBWoXFOrh4zTOAmzGlA8zaF6dJ0DQ/uGj8A+FX7P7gbgf+jSAoWdTcoL1DEnQM77xp9LFNr2bsooYGxHNmW+g0b4SFJCUKl+jlx97Hnny33sjK8VzL1NX386EOKFPUwKCtcxANdWFCq2ytxMYR+95lBmV2NplgXKs2zP75D+zQQlUqFkhCPxs2LxDtpT/2iC0ke86lz9QSt1qDsRYn3bmBTqAyxh7bpy6yLlCXh/gvTpKg1/6nPj4x4nlwVLOxGh2arCX3Nc/ImvA3nOS2WfPefqWQ4wbKk+a8KlHPn2dM4gh9E02tyBTxz2TOnzxEAWgwoStCDaB5eSxrTUKquL+0+K8mW+Ul3rsVEJrJh1hU+mFUZlVrF1UOBOLjaUKKmN9HPEti/1Phv9JvnXWPy/qa0HV6CU9seUadrfgpV9uSHj5O6EDVWKj5fU49cFV3p0uEvNBo1Pr5J32hCn8aQkJC5Gwm+n3eCBQtbcfb0E06desIngyrj4GDDH0svGF2Xo6M1BQslJw3587tRpqwP3oGOBD2Ios/kinjmdGDW+4f02xQsl/THy87RCldvWwqW8yAxXsv9q0nn/o/x5/h4TjWiwhM4vfMR1rZqilTywsndhvVzrhgd49afr9P6k+L0/bYSuxbdpFwDP+p2zs/YNsmtNQPnV6dO9/x82GkTUc/i8fZNGmMUER6XoTmqJs1rSNuuxV65/8+zTzH86xpcvRDM5QuBdHq3JIWLeTCg+xajX5MpqVRJCda2ZTfQag27/lr2Lsrda2GEBcVQurovw7+rwaq5F7l/IzyN2szDlNf0D/NPsnt/Lz4bWYP1a69SqUpO+vQtR+ymBfptHJp3R+3iQeSfP4CioA14YFCHEhkBiQn6cgWI+Xszjq17g0pNwt1rqOwcsM5fDCU2JvWux3TEHN6G60fjsK/TivhrZ7AtVwurXIWIXPv/u7TUGpzf/ZQKrn7Z9vPjTXBwtKbAC59JefO7UqqsD2GhMQQ8ieK3lW0oU8GXd9uvQ61R4/3/cxL2GufkTcju51lkntETjVqCOWdasXfJLeb1PYJ7Dnu88iQ3v6rUKnpNroBvASe0iTr8bz1jyZiz7Pz5hn6b5WPPER4US6fPS+P7sxNRYQncPhvCmqmXMhXPtaNBzHr3H96dUJ5ekyvw+N9nTO1wgPuXwwDwzOVAtTZJc9ocOdHXYN8WTVdw6J/UWxvSs+6va3h5OfDF2Dr4+jpy8UIgHduuJigw2ui6KlTMwbZdPfQ/T53eCIDdS27y3QeH8PBzwCev4TQCP5xuo/9/0cpeNOhRiIC7kfQp/BcAO3//l7joRDp9VpoPp1UmNiqRu5dC2TDX+OQKIOBuJGPb7OWjmVVoN7gkwQ+jmNP/CGd2Jd+I0WpAcQDW7OlisO+nH+7kr2XpH/e9j8qlu/9v889ia2vF2Bn1cPOw48qFIHq2WMu92+ZNVqo0ykWOfM76uwdflLeoKwMmVcHFw5YndyNZ/O05Vs15/TmeTM2U1/SZ0/707LqObybU4/MvanHvbhijR+7lG+fkLwlqZ3c0bmnf7Zua6F2r0UVFYN+gHU4eviixUSQ+ukP0/tSncUlP4r0bPFs5D4dm3XBo3h1t8BMils7QJ3VqVw9sS1UhN9n38+NNKF/Jj/W7kse9TpjREIBVyy4xc9JhmrdOusty/8k+Bvu1b7qKI38bJsrmlN3Pc2ZZ8t1/ppLhebAsibHzYGUXL86DZSkyMg9WdvPiPFiWxJTzYGUVU8+DlRUyMg9WdvTiPFiWwlTzYGUlU8+DlVWyeh6s33OYbo7Mvk/6pr9RNpThaRqEEEIIIUTGvJVdhEIIIYQwHxnkLgmWEEIIIUxMxmBJF6EQQgghhMlJC5YQQgghTOrtu33OeJJgCSGEEMKkZAyWdBEKIYQQQpictGAJIYQQwqRkkLskWEIIIYQwMSX7PI3IbKSLUAghhBDCxKQFSwghhBAmJYPcJcESQgghhInJGCzpIhRCCCGEMDlpwRJCCCGESclEo29pgrXf5pG5Q/jPOGztb+4Q/jPC1HHmDsFoTjprc4dgtILzKpo7hEx5GLzI3CEYLbfX++YOwWiWeE2bg3QRShehEEIIIYTJvZUtWEIIIYQwH+kilARLCCGEECYm0zRIF6EQQgghhMlJC5YQQgghTEonXYSSYAkhhBDCtGQMlnQRCiGEEEKYnLRgCSGEEMKkZB4sSbCEEEIIYWLSRShdhEIIIYQQJictWEIIIYQwKWnBkgRLCCGEECYmY7Cki1AIIYQQwuQkwcqgfh9V5OK1AQSGjmDf3+9RqXIOc4eUIZYYt8ScdbJz3NVq52LJunacufMRj+M+o3mbwgbrHRytmTynIadu9edW2BAOnOtDr35lzRTtq5nyPKtUCbi4Hcc755/45V6Kp+8WrG2CXrlPfDz8+D20bgE1q0GblrBpQ6ZDyJDTp+DdHknHa98GNm8yXL/od/D03Yxv7mX45FqJu9deNFbhr33c7HxNQ/rX9eO4z1JdBnxa2UwRZ45iwsVSSYKVAR06FWfKtIZ8O/kQdWos4uKFQNZt6oqXt4O5Q3slS4xbYs462T1uB0drLl8I4ouhe1NdP25Gfeo3zc/g97dRr9xiFs4/zeQ5jWjaqlAWR/pqpj7Prh6HsLF7THhIXYL82xEXmwsPn50EBqa9z5jP4eQJ+Oob+Gs9TJoC+fJn7vUAPH4MVSqmvf7RIxg2BCpVhuUroXsPmDwRjh5J3ubMaYiOLE5IQCueBjYDlQ4Pn52oVAmZjiu7X9OQ/nVdLu9PBsvwfjvQ6RS2rv83iyN9PTrFdIulkgQrAwYNqcqSRedZvuwi16+FMGzwDmJiEujVO3t+W37OEuOWmLNOdo97/867TB93mB2bbqa6vnL1nKxZdoWjfz/k4b0Ilv92kSsXgihf2S+LI301k55nVSJ2Dvd4FlaZ+Dg/tIkuRIZXQJvowto1qe9y5HBSMjNnPlSrBjlzQtlyUK684XYb1kPnDlCrOnTqAGv+ND6859b9BTlzwfBPoUBB6NINGjaCFcuTt5n/A8REFSExwZ3EBA/CQ+pgZRWFtU1Ipo+b3a9pSP+6DgqINliatS7M4YP3uX/n9Vv3RNaSBCsd1tZqylfwY/++u/oyRYED++5StWou8wWWDkuMW2LOOpYa94tOHXtM01aF8MvpBEDNenkoWMSdg3vumjewF5j6PKtQUKkUFEVjUK7oNJw7l/o+f/8NJUrC0iXQohl0bAdzZkNsbPI227fBzz/BgIHw51r4ZGDSz1s2Gx0iABcvQNWqhmXVa8DFi2nvo1LHA6DT2WbqmG/DNf0yLx8HGr1TgFWLLpk7FKMpSVerSRZLJXcRpsPTywErKzVBgVEG5YGBURQt5mmmqNJniXFLzFnHUuN+0VfD9jH9xyacufMRCQladDqFkQN2c/zQI3OHpmfq86wo1sTHeePkep6wEDd0WjvsHe5gbRtEcHDq+zx6COfPga0NzJgFYWEwbSqEh8E345O2+WUBDPs0qZUJIFcuuHMH1q2FVq2NDpOQEPB46eV5ekJUZFJiZ2eX4pXh4n6c+FgfEhPcjT8gb8c1/bIuvUoR+SyebRssq3sQLLtrz1QkwRJCWKS+AytQqVoOendYz8N7EVSvk5spcxsR8CSSf/bdN3d4b0xYSF1cPQ7hm2s1iqIiId6T2OgCqFW3U91eUUClgomTwck5qWzYpzB6FHw+Jmn9w4cwcULSOKnntFpwckr+uUsn8H+SXCdA3VrJ68tXgHnfZ+41ubgfxco6jJCAFpmr4C3VrXdp1q+6Rlyc1tyhiEyQBCsdIcHRJCbq8PZxNCj38XEkwD8qjb3MzxLjlpizjqXG/ZydnRWjJ9Tmgy4b2bv9DgBXLwVTqqwPHw+vnG0SrDdxnrWJLjwNbIFKlYBKlYBO54Cb535y5U59ey8v8PZOTq4AChRISpICA8Hx/6F9+RWULm24r/qFnsi58yAxMen/gUHwcb+kAezP2b7QKuXpCU9fGkoVEgKOTilbr1zcj2Jn/4CQgBbotIbnyRiWfk2/rGqtXBQu5sHHPbeYO5RMkQYsGYOVroQEHefO+lO/QX59mUoF9Rrk48SJ7NMV8TJLjFtizjqWGvdzVtZq/tfefYdHVebvH3+fSU8gAUIKJbSFVVRIKIJBEaQqRariLmKwoCCwImtdhQCuYhf5gcviF2kqRhEbKopxBVkpUg1SBEFAIJUUEkibOb8/IhNGSoqHTCZ7v7zmujKn3ieeyXx4nuec4+vrheN3/RB2hwObrfqM2biUv2fT9MHhCMQwCvALOMb13c6/XNtoSEuHU6dKpx0+DDYbhIeXFENhYSVX/kU1cX01OmvoUoOGpdMb/Hbng7OXDQ8vXbZNW/j+e9ccmzZCmzZn5z9TXB0mI/VG7Pba/BGefk7/3l9GX8WOLcnsSrr4LTiqK11FqBascpkzexPzXh/Ati3H2bz5OPdP6EhgoC9vLvnB3dEuyhNzK3PVqe65A4N8aP6nOs73Uc2CubJtGFmZ+Rw9cpLv1hxhysxu5J8u5tfDOcR2jWL4yCuY/sga94U+D6t/z77+RzEwKS4Kwcsnh+A6mykuCuHmm0u+iOf8P0hLhem/dffdeBMs+D+YMQ3uHQtZmTB7FgwcVNqadO9YePGFki7B2C5QVAi7dsHJkzDy9opnHDoc3k0o2c/Ng0qKra9Wwyuvli7z3LMQEHSAzLSemA4fbLaSCtBh+oJZua+m6n5OQ9nnNUCt2r4MHHYZ0x/9xj0hxRIqsMphxfI91K8fyD+mdiUiIoikH1IZNiiBtNRTZa/sRp6YW5mrTnXPHd0hgvdXj3C+n/7CDQAkLNnJg2O+YNyolfzjqa7MWdSPOvX8OXr4JM/F/5cl83e4K/J5Wf17ttkKqR2yBS/vPBwOP/JPNeVkVge8fUrugZCeDsnJpcsHBsLc1+CF5+GO2yEkBHr1hnH3ly4zeEhJsbV0SUlRFBAAf2pZcv+qymjUCGbNhpdfgneWQXgEPDGlpHg74/33So4lNOJzl3WzMq7jdF6rSu23up/TUPZ5DTDo1sswDPgwYY9bMlrBgxueLGOYZs17JGNwwLPujiAiQC2Hj7sjVFiurfI3unSnX9MXujtChTWuf6e7I1SYJ57TUHKH+Kr0uC3Bsm3NdIwoe6FqSGOwRERERCymLkIRERGxVI3rGqsEFVgiIiJiKYe7A1QD6iIUERERsZhasERERMRS6iJUgSUiIiIWUxehughFRERELKcWLBEREbFUzbvDZsWpBUtEREQs5bDwVREzZ87k6quvpnbt2oSHhzN48GD27t3rskx+fj7jx48nNDSUWrVqMWzYMFJSUlyWOXz4MP379ycwMJDw8HAefvhhis887bycVGCJiIhIjbBmzRrGjx/Phg0bWL16NUVFRfTp04e8vDznMg8++CCffPIJ7733HmvWrOHYsWMMHTrUOd9ut9O/f38KCwv57rvvWLx4MYsWLWLq1KkVyqJH5YjIJeOJjxXRo3Kqjh6VU3Wq+lE5DxjWPSrnVbPyj8pJS0sjPDycNWvWcP3115OdnU1YWBhvv/02w4cPB2DPnj20bt2a9evXc8011/D5558zYMAAjh07RkREBADz5s3j0UcfJS0tDV9f33LtWy1YIiIiYikruwgLCgrIyclxeRUUFJQrR3Z2NgD16tUDYMuWLRQVFdGrVy/nMpdffjlNmjRh/fr1AKxfv542bdo4iyuAvn37kpOTw48//lju34EKLBEREam2Zs6cSUhIiMtr5syZZa7ncDiYNGkS1157LVdddRUAycnJ+Pr6UqdOHZdlIyIiSE5Odi5zdnF1Zv6ZeeWlqwhFRETEUlbeB+vxxx9n8uTJLtP8/PzKXG/8+PHs3LmTdevWWZim/GpkgeVlGu6OUCl2o8YNh5P/caeNil11Ux146t8PTxzPdCR7vrsjVFhUyL3ujuARrPw28/PzK1dBdbYJEyawcuVK1q5dS+PGjZ3TIyMjKSwsJCsry6UVKyUlhcjISOcymzZtctnemasMzyxTHuoiFBERkRrBNE0mTJjABx98wNdff03z5s1d5nfo0AEfHx8SExOd0/bu3cvhw4eJjY0FIDY2lqSkJFJTU53LrF69muDgYK644opyZ6mRLVgiIiLiPu56VM748eN5++23+eijj6hdu7ZzzFRISAgBAQGEhIRw9913M3nyZOrVq0dwcDATJ04kNjaWa665BoA+ffpwxRVXMGrUKJ5//nmSk5N58sknGT9+fIVa0lRgiYiIiKVMNz3u+V//+hcA3bt3d5m+cOFCRo8eDcArr7yCzWZj2LBhFBQU0LdvX1577TXnsl5eXqxcuZJx48YRGxtLUFAQcXFxzJgxo0JZauR9sOr6P+fuCJWiMVhS03jqeCZP5Il/PzQGq+rknH6sSvd3n/GOZdv6t3mbZduqSmrBEhEREUu5q4uwOlGBJSIiIpbyvPZU6+kqQhERERGLqQVLRERELKUuQhVYIiIiYjHTAy+6sJq6CEVEREQsphYsERERsZS6CFVgiYiIiMVUYKmLsMImPdSZzPxHeeaFnu6OclFdro0iYflw9h4YT87px+g/sJW7I5WLJ+ae/NA1fLMujqOpD/LzoYm8/e5QWraq5+5YF3X3mHZ8t+kufk15kF9THuSrb0bRu08Ld8eqEE/5LD765LVk5j/q8tq44x53x7qoS3F+GEYRwXU2EtbwXSIbLyE0YiW7dl78RrSrVhr8dZg3Xa/25qYbvHlqihdZWX8oRpm2fG8w6lZvrm3vzdB+3qz80DVjUPAPhEZ8QkTjpYQ3Wkbd+ol4eWf/oX2Oua89SXvGkZr5EF+vvYMOHRv8oe1J9aACqwLadYhk9D0x7PwhteyF3SwoyIedSSn8fdJqd0epEE/MfV3XJsyft5We3ZYyaEACPt42Plw5gsBAH3dHu6CjR08ybco3dOuyiO7XLmLNN4dY9t4wLm9d393RysWTPosAu39M47Kmc5yvm3q85e5IF3Upzo+Qeuvw9T9Gdsb1pCUPpiC/EePHeJGacv7ld2wzmPaEF4OGOnjng2JmvmTnx50Gz0zzqnSGY0ehU5sLfy6P/goPjveiw9UO3lxezG23O3h6mhfr/1taZPn6JXMq93IyUgZwIrUvGA7qhX+BYRRVKtPQ4ZfzzHM9ePbpdXSNXUjSD6ms+HgE9cMCK7W96sK08D9PpQKrnIKCfJi/aCAP3L+KrKx8d8cp0+ovD/DU9G9Z+fFP7o5SIZ6Ye+igd3n7zST27E5nZ1IqY+/9lCZNQohpF+nuaBe06rP9fPnFAX7+OZP9+zN5atpa8nILubpTQ3dHK5OnfRYBiosdpKbkOV8nMk67O9JFWX5+GMX4Bx7iZFZHCgsisRcHk5vdjqgoeD/h/F9DSTsMGjSEESMdNGoMMe1Nhgx3sCvJtUXpw/cNbr3Zm+s6eHPLQG+Wv1P5r7UV79po2AgmPeygeQu49a8OevQ2Wba0dJuZaX04ndeK4qK6FBfVIzujK97eefj4ZlRqnxP+1onFC3fw1tIk9u7JYNLEVZw+XcSouLaVPo7qwGHhy1OpwCqnF17tzZef/8yarw+5O4pUcyHBJU9bz8ys3l+iZ9hsBsNuaU1gkA+bNh51d5wyeeJnsUXLuuw6cD/bdt/H/EUDaBxV292Rys2K88PAxDBMTNO19cnP32THtvN3E7aJNklJhv+uNTBNyEiHr1cbdOla2qKxaqXB/LlejPubnYSPirn/ATvz5thY+VHlnoGZtMOg0zWuX+nXdHGQtOPC2zNshQA4HH4V3p+Pj42YdpH85+tfnNNME775+hc6dWpU4e1J9aJB7uUw9JbWRMdE0uPaxe6OItWcYcCzL/Ri/XdH2L0r3d1xLuqKK8P46ptR+Pt7k5tbyMgRK9i7p3L/Cq8qnvhZ3LLpOOPHfMb+n04QEVmLR5+4ls8SR9Kl/Rvk5ha6O94FWXl+mKYPhQVh1ArZQVZGHRx2fwICD5K0w6Bxk/OvE93OZMazdp542IuCQrAXG3Tt7uCRJ+zOZea/5sUDD9m5oVdJ0dWoscmBnx188J6NAYPs59/wRWRkGNQLde2SqhcKebkG+fng73/OkRFcdyOF+eEUF9Wt8P5C6wfi7W0jLTXPZXpqah5/viy0wturTjy5a88qKrDK0KhxbWa+2JOh/RMoKKj4B1b+t7w0qw+trwyjb8833R2lTPt+yuC6zm8QHOLHoCGXM+/1AdzU561qW2R56mfxqy8POH/+cWcam78/RtJP4xg8/HLeXPSDG5NdnNXnR1bG9YTUW0dEowRM06CoMJQ+N5ns2XX+1qEDP8PLz3lx91gH13RxkJ5u8P9e8mLmU15MmWHn9Cn49YjBP+O9eGZa6Xp2O9SqVfp+xGBvko+V/HzmK79bp9Kvvpj2Jq/Oq9z5FFx3Pd4+WWSk9KvU+jWZJ3ftWUUFVhmi20USHhHENxtGO6d5e9vocl0UY8a1JyL4RRwOVeoCL77Smxv7teSmXm9x7OhJd8cpU1GRgwMHsgDYvi2F9h0aMG58RyZN/MK9wS6gpnwWc7IL2L/vBC3+VMfdUS7K6vPDXhzMidR+GEYRhlGEwxFIcfECGjU+//+zxf/nRdsYk1F3lnxVt7rMJCDAzr1x3oybaMf4rS57It7OlW1dt2E7a/DLrNeKKS4u+TktxWDsXd68ubzYOd/vrJ690FCTE7+rH09kQFAt85zWq+C66/EPOEJGSj8c9qDy/yLOkpF+iuJiB2HhruuHhweRkpx3gbXEU6jAKsPa/xyiS/sFLtPmzO/Hvp8yePXFjR7xB10uvRdf6c2Am/9M/z5vc+jQH7tk211sNgM/v+r7J6GmfBaDgnxo3qIOCW971heoVeeHafpgmj4YRgEbvjOY+OD5W4/y88HrdxcMnimcTBPqh0FYuMnRXw1uHHDh//cNzhqX7+VVslzUBbol20SbfPetjbPbXzaut9Em+uztmwTX3YB/wGEyUm/Ebq/8eLqiIgfbtyXT/YZmfPrJPqBkmEG3G5oyf97WSm+3OjArNwyuRqm+f02ridzcwnPG0pw6VcSJjPxqPcYmKMiHFn8qHRPQrFkd2rQNJzMzn1+P5Lgx2cV5Yu6XZ/Vh+Igr+Mst73Myt5DwiJJ/jeZkF5CfX1zG2u4RP6Mbq784wK9HcqhV25dbRlxB1+ubMGRggrujXZCnfhZnzLyBVZ/t58jhbBo0qM1jU67Dbjd5/91d7o52QZfi/PD1P4qBSXFRCF4+OQTX2Uyz5iYDB5cUL3Nn2UhNNZj+TEnB1bWbg6ene7E8wUbsb12ELz9n48o2DsLCS7Y55n47Lz3rRa3acM21DooKYfePBjk5BiPjKt5JNfRWB++9Y2P2yzZuHuxg8yYbiV8avDy3tAgMrruBgKADZKb1xHT4YLOdAsBh+oJZ8a/UObM3Me/1AWzbcpzNm49z/4SOBAb68uaS6tt9XB4OjcFSgVVTtWvfgM++/Kvz/cznS27G+NbSJMbd+6m7YpXJE3Pfc197AD5fPdJl+tgxn/L2m0nuiFSmsLBA/r1gAJGRQeRkF7BzZxpDBia4XM0k1mjUqDb/t3gg9UIDSE87zcbvfqV3t6VkpFffq0wvxflhsxVSO2QLXt55OBx+5J9qyux5KXj/dluq9DSDlOOlyw8YbJKX5+C9ZTZefdFG7drQsZPJhLNavAYPM/H3t/PmIi9mv2QjIAD+1MrktlGVGwHUqDG8MtfOK897kfCmjfAIeGKandhrS4uFoNp7AAiN+Nxl3ayM6zidV/EbI69Yvof69QP5x9SuREQEkfRDKsMGJZCWeqpSxyDVh2GaZo0rM+v6P+fuCJVi19PHpYbxUj9BlfHEvx9Hsue7O0KFRYXc6+4IlZJz+rEq3d9QL+su9Flhv92ybVUltWCJiIiIpXSbBt1oVERERMRyasESERERS+k+WCqwRERExGK6ilBdhCIiIiKWUwuWiIiIWEoXEKvAEhEREYupi1BdhCIiIiKWUwuWiIiIWEr3wVKBJSIiIhbTbRrURSgiIiJiObVgiYiIiKU0yF0FloiIiFhM5ZW6CEVEREQsVyNbsOyGamcRqRxP/fvR1F7b3REqLCrkXndHqLDkQwvdHaGSHqvSvTk89HNkpRpZYImIiIj7aAyWughFRERELKcWLBEREbGU2q9UYImIiIjF1EWoLkIRERERy6kFS0RERCylFiwVWCIiImIxPYtQXYQiIiIillMLloiIiFjKVBehCiwRERGxlsZgqYtQRERExHJqwRIRERFL6VmEKrBERETEYrqKUF2E5TbmvvYk7RlHauZDfL32Djp0bODuSOXiibmVuep4am6ASQ91JjP/UZ55oae7o1xUl2ujSFg+nL0HxpNz+jH6D2zl7kjnGDflapIKx7u8Pk76q3P+1Lnd+Wz37XyffR9rjt7F7Pf70fyyOu4LfBFWntOGUURwnY2ENXyXyMZLCI1YyY+7y7fu9h+gY3cYcWeld19uq/8DQ0ZC555wSxx8u750XlExvPovGDhwIDExMVx33XU88sgjpKSkXPpg/+NUYJXD0OGX88xzPXj26XV0jV1I0g+prPh4BPXDAt0d7aI8MbcyVx1PzQ3QrkMko++JYecPqe6OUqagIB92JqXw90mr3R3lovb9mEH3qIXO1x3dVzjn7dqaypQxiQxq+zZj+38MBvz705ux2Qw3Jj6X1ed0SL11+PofIzvjetKSB1OQ34ixD0Jq2sXXO3kSpjwNndpXarcuNm+DfrdceP72JHh8OgzuD8sWQPeuMPkfsP9Ayfz8fNj9E4wbN44VK1YwZ84cDh48yLhx4/54uItwYFr28lQqsMphwt86sXjhDt5amsTePRlMmriK06eLGBXX1t3RLsoTcytz1fHU3EFBPsxfNJAH7l9FVla+u+OUafWXB3hq+res/Pgnd0e5KHuxSUbKKecrK6P0d7t8wS62rDvOsUMn2b09nTnxG2nQpDYNm9V2Y+JzWXpOG8X4Bx7iZFZHCgsisRcHk5vdjqhG8N6HF1/1ny/Cjb2h7VXnznM4YMFS6H8rXNMTbh1d0gJVWcuWQ5dOEPdXaNEMxt8Drf8M7/xWH9euBfNegX79+tGiRQtiYmKYMmUKP/74I8eOHav8jstgWvifp1KBVQYfHxsx7SL5z9e/OKeZJnzz9S906tTIfcHK4Im5lbnqeGpugBde7c2Xn//Mmq8PuTtKjdKkZQiJv4zm8z238+zi3kRG1TrvcgGB3gy+43J+PZBN8pHcKk55YVaf0wYmhmFiml4u0/38YNsPF17vo0/h6HG4b/T557/xJnz6BTzxd1i+FG6/FZ78Z0lLVWX8sBM6d3SdFtupZPqF5ObmYhgGwcHBlduplIsGuZchtH4g3t420lLzXKanpubx58tC3ZSqbJ6YW5mrjqfmHnpLa6JjIulx7WJ3R6lRkjalMOWeRH75KYv6kYGMe/JqFn89lCHtlnEqtwiAEfddxeSZXQis5cPBvZmM6fcxxUXVZyiz1ee0afpQWBBGrZAdZGXUwWH3JyDwID/8CFEXqNcOHYHZ/4Y35oD3eb5dCwtLWq/mvQLRv7VuNW5YUrC9/zF0bFfhmKSfgHr1XKeF1oOME+dfvqCggBdffJH+/ftTq9b5i2greHLXnlVUYImIR2jUuDYzX+zJ0P4JFBTY3R2nRln3xWHnzz8lZZC0KYUv9t9B3+Et+WBRyajuT5f9xPrEI4RFBhI3uR0vvd2XUd1WUFiD/19kZVxPSL11RDRKwDQNigpDubFnyZim37Pb4R8zYOxd0LTJ+bd35GjJmKhxk12nFxXB5Wdd+9ClT+nPDjsUFrlO69cHnnyo4sdTVFTEAw88gGmaTJ8+veIbqAAVWCqwypSRforiYgdh4UEu08PDg0hJzrvAWu7nibmVuep4Yu7odpGERwTxzYbRzmne3ja6XBfFmHHtiQh+EYdDf9StcDK7kEP7smjSMsQ5LTenkNycQg7vz2bHxhT+m3oPPQe34POEfW5MWupSnNP24mBOpPbDMIowjCIcjkCK7QtpdJ4LE0+dgl17YO8+eG5WyTSHo6SbsmN3eO0lCPAvmT77OQgPc13f16f053feKP155y54dR68Prt0Wq2zDrF+PTjxu9aqjBMlrVhnKyoqYtKkSRw7dozFixdf0tYrKaExWGUoKnKwfVsy3W9o5pxmGNDthqZs2nTUfcHK4Im5lbnqeGLutf85RJf2C7i+00Lna+vm47z3zo9c32mhiisLBQT5ENUihLTjp8473zBKXr6+Xued7w6X8pw2TR8cjkAMo4DvNpVcqfd7QUHw3uKS4ujMa/ggaNak5Oc2V0CL5uDrC8kp0KSx6ysyonRbZ08PDwMvL9dp9eqWLtv2Kti0xTXLhs2uA+yLimHSpEkcOnSIRYsWUbduXS41XUWoFqxymTN7E/NeH8C2LcfZvPk490/oSGCgL28uuchIx2rAE3Mrc9XxtNy5uYXs3pXuMu3UqSJOZOSfM706CQryocWfSr/QmjWrQ5u24WRm5vPrkRw3Jiv192e7sObTXzh2+CRhDYIYP7UTdrvJ5wk/0bh5MH1vacn61Uc4kX6aiEa1uPuR9hSctvPtqup1oYHV57Sv/1EMTIqLQvDyySG4zmaaN4Gb+5XMnz0PUtPhn0+CzQYtW7iuX69uSUF19vQ7boOX5oDDhHZtITe35FYLQUFw800Vz/iX4TBmIix5B7rGwheJJS1pUx4umV9UDA9Pgb37d/Lvf/8bu91OWlrJfSZCQkLw9fWtxG+mbJ5cGFlFBVY5rFi+h/r1A/nH1K5ERASR9EMqwwYlkJZ6/n/dVReemFuZq46n5vY07do34LMvS2/aOfP5khujvrU0iXH3fuquWC4iGtfiuaV9qBPqT2baabZ+d5yRXZeTmZ6Pt4+NDtc2ZNTEaILr+pGRcoot644zqtv7nEg77e7oLqw+p222QmqHbMHLOw+Hw4/8U02Z+9IJfH775kzPKGmNqoj774G6dWDhm/DUsZLbKLT+M9w1qlIRiWkDz8TD3NdhzvySFq6Xnykt6tLSYM06gGQGDRrksu6SJUvo3Llz5XYsZTJM06xxZWZwwLPujiAigJdZvW5EWR52D32GWlN79bonVXkc8jrp7ggVlnxoobsjVEpg+N4q3V8rv9llL1RO+wr+Ztm2qpJasERERMRS6iLUIHcRERERy6kFS0RERCylFiwVWCIiImIxuwosdRGKiIiIWE0tWCIiImIpdRGqwBIRERGLqcBSF6GIiIiI5dSCJSIiIpayGw53R3A7tWCJiIiIpeyYlr0qY+7cuTRr1gx/f386d+7Mpk2bLD7CsqnAEhERkRojISGByZMnEx8fz9atW4mOjqZv376kpqZWaQ4VWCIiImIpd7Zgvfzyy4wZM4Y777yTK664gnnz5hEYGMgbb7xxCY70wlRgiYiIiKXshmnZqyIKCwvZsmULvXr1ck6z2Wz06tWL9evXW32YF6VB7iIiIlJtFRQUUFBQ4DLNz88PPz+/c5ZNT0/HbrcTERHhMj0iIoI9e/Zc0py/VyMLrJzTj12S7RYUFDBz5kwef/zx8/6PrY48MbOISPV1ab5fahorv4enTZvG9OnTXabFx8czbdo0y/ZxKRimaepuYOWUk5NDSEgI2dnZBAcHuztOuXhiZhERkTMq0oJVWFhIYGAgy5cvZ/Dgwc7pcXFxZGVl8dFHH13quE4agyUiIiLVlp+fH8HBwS6vC/XI+Pr60qFDBxITE53THA4HiYmJxMbGVlVkoIZ2EYqIiMj/psmTJxMXF0fHjh3p1KkTs2bNIi8vjzvvvLNKc6jAEhERkRpjxIgRpKWlMXXqVJKTk4mJiWHVqlXnDHy/1FRgVYCfnx/x8fEeNVjcEzOLiIj8ERMmTGDChAluzaBB7iIiIiIW0yB3EREREYupwBIRERGxmAosEREREYupwCqnuXPn0qxZM/z9/encuTObNm1ydyQXa9euZeDAgTRs2BDDMPjwww9d5pumydSpU2nQoAEBAQH06tWLffv2uSesiIhIDacCqxwSEhKYPHky8fHxbN26lejoaPr27Utqaqq7oznl5eURHR3N3Llzzzv/+eefZ/bs2cybN4+NGzcSFBRE3759yc/Pr+KkIiIiNZ+uIiyHzp07c/XVVzNnzhyg5K6wUVFRTJw4kcceq37PpTIMgw8++MD5mADTNGnYsCF///vfeeihhwDIzs4mIiKCRYsWcdttt7kxrYiISM2jFqwyFBYWsmXLFnr16uWcZrPZ6NWrF+vXr3djsvI7ePAgycnJLscQEhJC586dPeYYREREPIkKrDKkp6djt9vPuQNsREQEycnJbkpVMWdyevIxiIiIeBIVWCIiIiIWU4FVhvr16+Pl5UVKSorL9JSUFCIjI92UqmLO5PTkYxAREfEkKrDK4OvrS4cOHUhMTHROczgcJCYmEhsb68Zk5de8eXMiIyNdjiEnJ4eNGzd6zDGIiIh4Ej3suRwmT55MXFwcHTt2pFOnTsyaNYu8vDzuvPNOd0dzys3NZf/+/c73Bw8eZPv27dSrV48mTZowadIk/vnPf9KqVSuaN2/OlClTaNiwofNKQxEREbGOCqxyGDFiBGlpaUydOpXk5GRiYmJYtWrVOYPG3Wnz5s3ccMMNzveTJ08GIC4ujkWLFvHII4+Ql5fHvffeS1ZWFtdddx2rVq3C39/fXZFFRERqLN0HS0RERMRiGoMlIiIiYjEVWCIiIiIWU4ElIiIiYjEVWCIiIiIWU4ElIiIiYjEVWCIiIiIWU4ElIiIiYjEVWCIiIiIWU4ElIn+IYRh8+OGH7o4hIlKtqMAS8RDr16/Hy8uL/v37V3jdZs2aMWvWLOtDldORI0e46667aNiwIb6+vjRt2pQHHniAjIyMCm3nl19+wTAMtm/ffklyqlgUEauowBLxEAsWLGDixImsXbuWY8eOuTtOuR04cICOHTuyb98+li1bxv79+5k3bx6JiYnExsZy4sQJd0cUEbGcCiwRD5Cbm0tCQgLjxo2jf//+LFq06JxlPvnkE66++mr8/f2pX78+Q4YMAaB79+4cOnSIBx98EMMwMAwDgGnTphETE+OyjVmzZtGsWTPn+++//57evXtTv359QkJC6NatG1u3bq1Q9vHjx+Pr68uXX35Jt27daNKkCTfddBNfffUVR48e5YknnnAue74WpDp16jiPt3nz5gC0a9cOwzDo3r07AKNHj2bw4MFMnz6dsLAwgoODGTt2LIWFhc7tnK8VLyYmhmnTpjnnAwwZMgTDMFx+DyIiFaUCS8QDvPvuu1x++eVcdtll3H777bzxxhuc/Zz2Tz/9lCFDhtCvXz+2bdtGYmIinTp1AmDFihU0btyYGTNmcPz4cY4fP17u/Z48eZK4uDjWrVvHhg0baNWqFf369ePkyZPlWv/EiRN88cUX3H///QQEBLjMi4yMZOTIkSQkJFDeZ85v2rQJgK+++orjx4+zYsUK57zExER2797NN998w7Jly1ixYgXTp08v55GWFJMACxcu5Pjx4873IiKV4e3uACJStgULFnD77bcDcOONN5Kdnc2aNWucLThPP/00t912m0tBER0dDUC9evXw8vKidu3aREZGVmi/PXr0cHk/f/586tSpw5o1axgwYECZ6+/btw/TNGnduvV557du3ZrMzEzS0tIIDw8vc3thYWEAhIaGnnMsvr6+vPHGGwQGBnLllVcyY8YMHn74YZ566ilstrL/LXlm23Xq1Knw70lE5PfUgiVSze3du5dNmzbxl7/8BQBvb29GjBjBggULnMts376dnj17Wr7vlJQUxowZQ6tWrQgJCSE4OJjc3FwOHz5coe2Ut4Xqj4iOjiYwMND5PjY2ltzcXI4cOXLJ9y0i8ntqwRKp5hYsWEBxcTENGzZ0TjNNEz8/P+bMmUNISMg53W/lYbPZzil8ioqKXN7HxcWRkZHBq6++StOmTfHz8yM2NtZlbNPFtGzZEsMw2L17t3NM2Nl2795N3bp1na1HhmGUmamyynO8IiJWUQuWSDVWXFzMkiVLeOmll9i+fbvztWPHDho2bMiyZcsAaNu2LYmJiRfcjq+vL3a73WVaWFgYycnJLkXH729/8N///pe//e1v9OvXjyuvvBI/Pz/S09PLnT80NJTevXvz2muvcfr0aZd5ycnJvPXWW4wYMcI58D4sLMxljNi+ffs4deqUy3EA5xwLwI4dO1z2sWHDBmrVqkVUVNR5t52Tk8PBgwddtuHj43PebYuIVJQKLJFqbOXKlWRmZnL33Xdz1VVXubyGDRvm7CaMj49n2bJlxMfHs3v3bpKSknjuueec22nWrBlr167l6NGjzgKpe/fupKWl8fzzz/Pzzz8zd+5cPv/8c5f9t2rViqVLl7J79242btzIyJEjK9xaNmfOHAoKCujbty9r167lyJEjrFq1it69e9OoUSOefvpp57I9evRgzpw5bNu2jc2bNzN27Fh8fHyc88PDwwkICGDVqlWkpKSQnZ3tnFdYWMjdd9/Nrl27+Oyzz4iPj2fChAnO8Vc9evRg6dKlfPvttyQlJREXF4eXl5dL1mbNmpGYmEhycjKZmZkVOk4RERemiFRbAwYMMPv163feeRs3bjQBc8eOHaZpmub7779vxsTEmL6+vmb9+vXNoUOHOpddv3692bZtW9PPz888+2P/r3/9y4yKijKDgoLMO+64w3z66afNpk2bOudv3brV7Nixo+nv72+2atXKfO+998ymTZuar7zyinMZwPzggw8uehy//PKLGRcXZ0ZERJg+Pj5mVFSUOXHiRDM9Pd1luaNHj5p9+vQxg4KCzFatWpmfffaZGRISYi5cuNC5zOuvv25GRUWZNpvN7Natm2maphkXF2cOGjTInDp1qhkaGmrWqlXLHDNmjJmfn+9cLzs72xwxYoQZHBxsRkVFmYsWLTKjo6PN+Ph45zIff/yx2bJlS9Pb29vl9yAiUlGGaVbB6FMRkUto9OjRZGVl6S7sIlJtqItQRERExGIqsEREREQspi5CEREREYupBUtERETEYiqwRERERCymAktERETEYiqwRERERCymAktERETEYiqwRERERCymAktERETEYiqwRERERCymAktERETEYv8fzK0VoDVfeC4AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.heatmap(cm,cmap='plasma',annot=True, xticklabels=[0, 10],yticklabels=[0, 10])\n",
+    "plt.xlabel(\"Actual Output\")\n",
+    "plt.ylabel(\"Predicted Output\")\n",
+    "plt.title(\"Fashion MNSIT conf matrix\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b48e8f3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (TensorFlow)",
+   "language": "python",
+   "name": "tfenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request adds a Jupyter notebook that demonstrates evaluation of a model on the Fashion-MNIST dataset using a confusion matrix.

The notebook includes:
- Loading and preprocessing Fashion-MNIST data
- Model prediction evaluation
- Confusion matrix visualization using seaborn and matplotlib

The notebook is self-contained and can be run after installing the required Python dependencies.
